### PR TITLE
Run tests within the same python process

### DIFF
--- a/tests/test_hooks/test_attribute_checker.py
+++ b/tests/test_hooks/test_attribute_checker.py
@@ -25,14 +25,14 @@ class AttributeCheckerTests(ConanClientTestCase):
 
     def test_conanfile_basic(self):
         tools.save('conanfile.py', content=self.conanfile_basic)
-        output = self.conan(['conan', 'export', '.', 'name/version@jgsogo/test'])
+        output = self.conan(['export', '.', 'name/version@jgsogo/test'])
         self.assertIn("pre_export(): WARN: Conanfile doesn't have 'url'", output)
         self.assertIn("pre_export(): WARN: Conanfile doesn't have 'license'", output)
         self.assertIn("pre_export(): WARN: Conanfile doesn't have 'description'", output)
 
     def test_conanfile_alias(self):
         tools.save('conanfile.py', content=self.conanfile_alias)
-        output = self.conan(['conan', 'export', '.', 'name/version@jgsogo/test'])
+        output = self.conan(['export', '.', 'name/version@jgsogo/test'])
         self.assertNotIn("pre_export(): WARN: Conanfile doesn't have 'url'", output)
         self.assertNotIn("pre_export(): WARN: Conanfile doesn't have 'license'", output)
         self.assertNotIn("pre_export(): WARN: Conanfile doesn't have 'description'", output)

--- a/tests/utils/test_cases/conan_client.py
+++ b/tests/utils/test_cases/conan_client.py
@@ -2,11 +2,26 @@
 
 import os
 import shutil
-import subprocess
 import tempfile
 import unittest
+from io import StringIO
 
+from conans.client.command import Conan, CommandOutputer, Command, SUCCESS
 from tests.utils.environ_vars import context_env
+
+
+class OutputStream(object):
+    def __init__(self):
+        self._data = StringIO()
+
+    def write(self, data):
+        self._data.write(data)
+
+    def flush(self):
+        pass
+
+    def as_str(self):
+        return self._data.getvalue()
 
 
 class ConanClientTestCase(unittest.TestCase):
@@ -19,11 +34,18 @@ class ConanClientTestCase(unittest.TestCase):
         kwargs.update({'CONAN_USER_HOME': home, 'CONAN_USER_HOME_SHORT': home_short})
         return kwargs
 
-    def conan(self, *command, **kwargs):
+    def conan(self, *command, expected_return_code=SUCCESS):
         with context_env(**self._get_environ()):
-            p = subprocess.Popen(*command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            out, err = p.communicate()
-            return out.decode()
+            # This snippet reproduces code from conans.client.command.main, we cannot directly
+            # use it because in case of error it is exiting the python interpreter :/
+            conan_api, cache, user_io = Conan.factory()
+            output_stream = OutputStream()
+            user_io.out._stream = output_stream
+            outputer = CommandOutputer(user_io, cache)
+            cmd = Command(conan_api, cache, user_io, outputer)
+            return_code = cmd.run(*command)
+            self.assertEqual(return_code, expected_return_code)
+            return output_stream.as_str()
 
     @classmethod
     def setUpClass(cls):

--- a/tests/utils/test_cases/conan_client.py
+++ b/tests/utils/test_cases/conan_client.py
@@ -52,13 +52,4 @@ class ConanClientTestCase(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         os.chdir(cls._old_cwd)
-
-        def _change_permissions(func, path, exc_info):
-            if not os.access(path, os.W_OK):
-                os.chmod(path, stat.S_IWUSR)
-                func(path)
-            else:
-                raise OSError(
-                    "Cannot change permissions for {}! Exception info: {}".format(path, exc_info))
-
-        shutil.rmtree(cls._working_dir, onerror=_change_permissions)
+        shutil.rmtree(cls._working_dir)

--- a/tests/utils/test_cases/conan_client.py
+++ b/tests/utils/test_cases/conan_client.py
@@ -34,7 +34,7 @@ class ConanClientTestCase(unittest.TestCase):
         kwargs.update({'CONAN_USER_HOME': home, 'CONAN_USER_HOME_SHORT': home_short})
         return kwargs
 
-    def conan(self, *command, expected_return_code=SUCCESS):
+    def conan(self, command, expected_return_code=SUCCESS):
         with context_env(**self._get_environ()):
             # This snippet reproduces code from conans.client.command.main, we cannot directly
             # use it because in case of error it is exiting the python interpreter :/
@@ -43,7 +43,7 @@ class ConanClientTestCase(unittest.TestCase):
             user_io.out._stream = output_stream
             outputer = CommandOutputer(user_io, cache)
             cmd = Command(conan_api, cache, user_io, outputer)
-            return_code = cmd.run(*command)
+            return_code = cmd.run(command)
             self.assertEqual(return_code, expected_return_code)
             return output_stream.as_str()
 

--- a/tests/utils/test_cases/conan_client.py
+++ b/tests/utils/test_cases/conan_client.py
@@ -2,7 +2,6 @@
 
 import os
 import shutil
-import stat
 import tempfile
 import unittest
 from io import StringIO
@@ -13,6 +12,8 @@ from tests.utils.environ_vars import context_env
 
 class ConanClientTestCase(unittest.TestCase):
     """ Helper class to run isolated conan commands """
+    _old_cwd = None
+    _working_dir = None
 
     def _get_environ(self, **kwargs):
         # kwargs = super(ConanClientTestCase, **kwargs)
@@ -40,7 +41,7 @@ class ConanClientTestCase(unittest.TestCase):
                 self.assertEqual(return_code, expected_return_code,
                                  msg="Unexpected return code\n\n{}".format(output_stream.getvalue()))
             finally:
-                conan_api._remote_manager._auth_manager._localdb.connection.close() # Close sqlite3
+                conan_api._remote_manager._auth_manager._localdb.connection.close()  # Close sqlite3
             return output_stream.getvalue()
 
     @classmethod

--- a/tests/utils/test_cases/conan_client.py
+++ b/tests/utils/test_cases/conan_client.py
@@ -30,9 +30,17 @@ class ConanClientTestCase(unittest.TestCase):
             user_io.out._stream = output_stream
             outputer = CommandOutputer(user_io, cache)
             cmd = Command(conan_api, cache, user_io, outputer)
-            return_code = cmd.run(command)
-            self.assertEqual(return_code, expected_return_code,
-                             msg="Unexpected return code\n\n{}".format(output_stream.getvalue()))
+            try:
+                return_code = cmd.run(command)
+            except Exception as e:
+                # Conan execution failed
+                self.fail("Conan execution for this test failed with {}: {}".format(type(e), e))
+            else:
+                # Check return code
+                self.assertEqual(return_code, expected_return_code,
+                                 msg="Unexpected return code\n\n{}".format(output_stream.getvalue()))
+            finally:
+                conan_api._remote_manager._auth_manager._localdb.connection.close() # Close sqlite3
             return output_stream.getvalue()
 
     @classmethod


### PR DESCRIPTION
Hi! I want to share with you this _trick_ to run the tests, I'm calling the Conan `main` function (not actually because it contains some `sys.exit` calls in case of failure) to run the commands.

We think this is almost the best approach to run the tests:
 * hooks are actually tested using actual Conan flow
 * we run the code for several Conan versions, we are checking not only the compatibility regarding the input parameters, but also the tools that could be used inside the hooks.
 * we can mock whatever we want, we are inside the same python process 💯 

Let me know your thoughts about it.
