### PR TITLE
Improve error message (#41)

### DIFF
--- a/hooks/bintray_updater.py
+++ b/hooks/bintray_updater.py
@@ -65,7 +65,7 @@ def _extract_user_repo(remote):
     pattern = r'https?:\/\/api.bintray.com\/conan\/(.*)\/(.*)'
     match = re.match(pattern=pattern, string=remote.url)
     if not match:
-        raise ValueError("Could not extract subject and repo from %s: Invalid pattern" % remote.url)
+        raise ValueError("The remote {} is not a Bintray repository." % remote.name)
     return match.group(1), match.group(2)
 
 


### PR DESCRIPTION
Hi!

The message reported on #41 is not clear enough, because only a pattern is used to compare the remote address, but there is no detail about. I think the user only wants to know if the remote is valid to be updated.

fixes #41 
