### PR TITLE
Add tests for hook loader: colliding files and modules

### DIFF
--- a/tests/test_hook_loader/test_colliding_files.py
+++ b/tests/test_hook_loader/test_colliding_files.py
@@ -1,0 +1,55 @@
+# coding=utf-8
+
+import os
+import textwrap
+
+from conans import tools
+from tests.utils.test_cases.conan_client import ConanClientTestCase
+
+
+def _create_hook(tempfolder, hook_filename, value):
+    utils_file = textwrap.dedent("""
+        def get_number():
+            return {}
+    """.format(value))
+
+    hook_file = textwrap.dedent("""
+        from utils import get_number
+
+        def pre_export(output, conanfile, *args, **kwargs):
+            output.info(">>>> {}")
+            output.info(">>>> {{}}".format(get_number()))
+    """.format(hook_filename))
+
+    tools.save(os.path.join(tempfolder, hook_filename + '.py'), hook_file)
+    tools.save(os.path.join(tempfolder, "utils.py"), utils_file)
+
+    return os.path.join(tempfolder, hook_filename)
+
+
+class CollidingFilesInRootTests(ConanClientTestCase):
+    conanfile = textwrap.dedent("""\
+        from conans import ConanFile
+
+        class AConan(ConanFile):
+            pass
+        """)
+
+    def _get_environ(self, **kwargs):
+        hook1 = _create_hook(self._gimme_tmp(), "hook1", "42")
+        hook2 = _create_hook(self._gimme_tmp(), "hook2", "23")
+
+        kwargs = super(CollidingFilesInRootTests, self)._get_environ(**kwargs)
+        kwargs.update({'CONAN_HOOKS': ','.join([hook1, hook2, ])})
+        return kwargs
+
+    def test_colliding_files(self):
+        tools.save('conanfile.py', content=self.conanfile)
+        output = self.conan(['export', '.', 'name/version@jgsogo/test'])
+
+        self.assertIn(">>>> hook1", output)
+        self.assertIn(">>>> 42", output)
+
+        self.assertIn(">>>> hook2", output)
+        self.assertIn(">>>> 23", output)
+

--- a/tests/test_hook_loader/test_colliding_module.py
+++ b/tests/test_hook_loader/test_colliding_module.py
@@ -1,0 +1,71 @@
+# coding=utf-8
+
+import os
+import textwrap
+import unittest
+
+import six
+
+from conans import tools
+from tests.utils.environ_vars import context_env
+from tests.utils.test_cases.conan_client import ConanClientTestCase
+
+
+def _create_hook(tempfolder, hook_filename, value, add_init):
+    func_file = textwrap.dedent("""
+        def get_number():
+            return {}
+    """.format(value))
+
+    hook_file = textwrap.dedent("""
+        from utils.func import get_number
+
+        def pre_export(output, conanfile, *args, **kwargs):
+            output.info(">>>> {}")
+            output.info(">>>> {{}}".format(get_number()))
+    """.format(hook_filename))
+
+    tools.save(os.path.join(tempfolder, hook_filename + '.py'), hook_file)
+    tools.save(os.path.join(tempfolder, "utils", "func.py"), func_file)
+    if add_init:
+        tools.save(os.path.join(tempfolder, "utils", "__init__.py"), "")
+
+    return os.path.join(tempfolder, hook_filename)
+
+
+class CollidingModuleTests(ConanClientTestCase):
+    conanfile = textwrap.dedent("""\
+        from conans import ConanFile
+
+        class AConan(ConanFile):
+            pass
+        """)
+
+    @unittest.skipIf(six.PY2, "Python 2 requires __init__.py file in modules")
+    def test_py3_colliding_module(self):
+        hook1 = _create_hook(self._gimme_tmp(), "hook1", "42", add_init=False)
+        hook2 = _create_hook(self._gimme_tmp(), "hook2", "23", add_init=False)
+
+        with context_env(CONAN_HOOKS=','.join([hook1, hook2, ])):
+            tools.save('conanfile.py', content=self.conanfile)
+            output = self.conan(['export', '.', 'name/version@jgsogo/test'])
+
+        self.assertIn(">>>> hook1", output)
+        self.assertIn(">>>> 42", output)
+
+        self.assertIn(">>>> hook2", output)
+        self.assertIn(">>>> 23", output)
+
+    def test_colliding_module(self):
+        hook1 = _create_hook(self._gimme_tmp(), "hook1", "42", add_init=True)
+        hook2 = _create_hook(self._gimme_tmp(), "hook2", "23", add_init=True)
+
+        with context_env(CONAN_HOOKS=','.join([hook1, hook2, ])):
+            tools.save('conanfile.py', content=self.conanfile)
+            output = self.conan(['export', '.', 'name/version@jgsogo/test'])
+
+        self.assertIn(">>>> hook1", output)
+        self.assertIn(">>>> 42", output)
+
+        self.assertIn(">>>> hook2", output)
+        self.assertIn(">>>> 23", output)


### PR DESCRIPTION
This PR adds some tests trying to demonstrate what happens if several hooks try to import modules/files with the same name.

It is related to the PR proposed here: https://github.com/conan-io/conan/pull/4641 and https://github.com/conan-io/conan/pull/4664. Nevertheless, the loading function is not the same for the `HookManager` and the `conanfile.py`.

Fails here are not solvable in the hooks side.