### PR TITLE
fPIC should not always be removed

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -245,7 +245,7 @@ def pre_build(output, conanfile, **kwargs):
         has_fpic = conanfile.options.get_safe("fPIC")
         if conanfile.settings.get_safe("os") == "Windows" and has_fpic:
             out.error("'fPIC' option not managed correctly. Please remove it for Windows "
-                        "configurations: del self.options.fpic")
+                      "configurations: del self.options.fpic")
         elif has_fpic:
             out.success("OK. 'fPIC' option found and apparently well managed")
         else:

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -242,7 +242,7 @@ def pre_build(output, conanfile, **kwargs):
 
     @run_test("KB-H007", output)
     def test(out):
-        has_fpic = conanfile.options.get_safe("fPIC") or conanfile.options.get_safe("fpic")
+        has_fpic = conanfile.options.get_safe("fPIC")
         if conanfile.settings.get_safe("os") == "Windows" and has_fpic:
             out.error("'fPIC' option not managed correctly. Please remove it for Windows "
                         "configurations: del self.options.fpic")

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -5,6 +5,8 @@ import os
 from logging import WARNING, ERROR, INFO, DEBUG, NOTSET
 
 from conans import tools, Settings
+from conans.client import conan_api
+from conans.errors import ConanInvalidConfiguration
 
 kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H002": "REFERENCE LOWERCASE",
@@ -155,8 +157,17 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
                     and any(r in low for r in remove_fpic_option):
                 out.success("OK. 'fPIC' option found and apparently well managed")
             else:
-                out.error("'fPIC' option not managed correctly. Please remove it for Windows "
-                          "configurations: del self.options.fpic")
+                conan_instance, _, _ = conan_api.Conan.factory()
+                try:
+                    conan_instance.info(conanfile_path, settings=["os=Windows"])
+                    out.error("'fPIC' option not managed correctly. Please remove it for Windows "
+                            "configurations: del self.options.fpic")
+                except ConanInvalidConfiguration:
+                    out.success("'fPIC' has not been removed, but this recipe is not supported by "
+                                "Windows.")
+                except:
+                    out.error("'fPIC' option not managed correctly. Please remove it for Windows "
+                            "configurations: del self.options.fpic")
         else:
             out.info("'fPIC' option not found")
 

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -38,6 +38,25 @@ class ConanCenterTests(ConanClientTestCase):
             def package_id(self):
                 self.info.header_only()
         """)
+    conanfile_linux_only = textwrap.dedent("""\
+        from conans import ConanFile
+        from conans.errors import ConanInvalidConfiguration
+
+        class LinuxOnly(ConanFile):
+            url = "fake_url.com"
+            license = "fake_license"
+            description = "whatever"
+            settings = "os", "arch", "compiler", "build_type"
+            options = {"fPIC": [True, False], "shared": [True, False]}
+            default_options = {"fPIC": True, "shared": False}
+
+            def configure(self):
+                if self.settings.os == "Windows":
+                    raise ConanInvalidConfiguration("Linux only!")
+
+            def package(self):
+                self.copy("*", dst="include")
+        """)
     conanfile_header_only = conanfile_base.format(placeholder='')
     conanfile_installer = conanfile_base.format(placeholder='settings = "os_build"')
     conanfile = conanfile_base.format(placeholder='settings = "os"')
@@ -114,3 +133,15 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [PACKAGE LICENSE (KB-H012)] No 'licenses' folder found in package", output)
         self.assertIn("[DEFAULT PACKAGE LAYOUT (KB-H013)] OK", output)
         self.assertIn("[SHARED ARTIFACTS (KB-H015)] OK", output)
+
+    def test_conanfile_linux_only(self):
+        tools.save('conanfile.py', content=self.conanfile_linux_only)
+        output = self.conan(['create', '.', 'linuxonly/version@conan/test'])
+        self.assertIn("[RECIPE METADATA (KB-H003)] OK", output)
+        self.assertIn("[FPIC OPTION (KB-H006)] OK", output)
+        self.assertIn("[FPIC MANAGEMENT (KB-H007)] 'fPIC' has not been removed, but this recipe is "
+                      "not supported by Windows.", output)
+        self.assertIn("[LIBCXX MANAGEMENT (KB-H011)] OK", output)
+        self.assertIn("ERROR: [MATCHING CONFIGURATION (KB-H014)] Empty package", output)
+        self.assertIn("ERROR: [MATCHING CONFIGURATION (KB-H014)] Packaged artifacts does not match",
+                      output)

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -140,11 +140,6 @@ class ConanCenterTests(ConanClientTestCase):
     def test_conanfile_linux_only(self):
         tools.save('conanfile.py', content=self.conanfile_linux_only)
         output = self.conan(['create', '.', 'linuxonly/version@conan/test'])
-        self.assertIn("[RECIPE METADATA (KB-H003)] OK", output)
         self.assertIn("[FPIC OPTION (KB-H006)] OK", output)
-        self.assertIn("[FPIC MANAGEMENT (KB-H007)] 'fPIC' has not been removed, but this recipe is "
-                      "not supported by Windows.", output)
-        self.assertIn("[LIBCXX MANAGEMENT (KB-H011)] OK", output)
-        self.assertIn("ERROR: [MATCHING CONFIGURATION (KB-H014)] Empty package", output)
-        self.assertIn("ERROR: [MATCHING CONFIGURATION (KB-H014)] Packaged artifacts does not match",
-                      output)
+        self.assertIn("[FPIC MANAGEMENT (KB-H007)] 'fPIC' has not been removed, but this recipe is"
+                      " not supported by Windows.", output)

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -2,6 +2,8 @@
 
 import os
 import textwrap
+import platform
+import unittest
 
 from conans import tools
 
@@ -134,6 +136,7 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("[DEFAULT PACKAGE LAYOUT (KB-H013)] OK", output)
         self.assertIn("[SHARED ARTIFACTS (KB-H015)] OK", output)
 
+    @unittest.skipIf(platform.system() != "Linux", "Only linux")
     def test_conanfile_linux_only(self):
         tools.save('conanfile.py', content=self.conanfile_linux_only)
         output = self.conan(['create', '.', 'linuxonly/version@conan/test'])

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -170,7 +170,11 @@ class ConanCenterTests(ConanClientTestCase):
         tools.save('conanfile.py', content=conanfile)
         output = self.conan(['create', '.', 'package/version@conan/test'])
         self.assertIn("[FPIC OPTION (KB-H006)] OK", output)
-        self.assertIn("[FPIC MANAGEMENT (KB-H007)] 'fPIC' option not found", output)
+        if platform.system() == "Windows":
+            self.assertIn("[FPIC MANAGEMENT (KB-H007)] 'fPIC' option not found", output)
+        else:
+            self.assertIn("[FPIC MANAGEMENT (KB-H007)] OK. 'fPIC' option found and apparently well "
+                          "managed", output)
         self.assertIn("[FPIC MANAGEMENT (KB-H007)] OK", output)
 
     def test_fpic_remove_windows_configuration(self):


### PR DESCRIPTION
The Conan Center hooks, validates when fPIC is declared in the recipe, but also requires that fPIC must be removed for Windows. However, some project are not supported on Linux (e.g. libmount), so there is no need for such action.

This PR runs `conan info` to validate the recipe support for Windows. If ConanInvalidConfiguration is raise, it's because the recipe can't be built on Windows, so we don't need to remove fPIC from the recipe. 

Related PR: https://github.com/conan-io/conan-center-index/pull/123