### PR TITLE
Remove cppstd for C projects

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -25,7 +25,8 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H018": "LIBTOOL FILES PRESENCE",
              "KB-H019": "CMAKE FILE NOT IN BUILD FOLDERS",
              "KB-H020": "PC-FILES",
-             "KB-H021": "MS RUNTIME FILES"}
+             "KB-H021": "MS RUNTIME FILES",
+             "KB-H022": "CPPSTD MANAGEMENT"}
 
 
 class _HooksOutputErrorCollector(object):
@@ -226,24 +227,38 @@ def pre_source(output, conanfile, conanfile_path, **kwargs):
 
 @raise_if_error_output
 def post_source(output, conanfile, conanfile_path, **kwargs):
+
+    def _is_removing_libcxx():
+        conanfile_content = tools.load(conanfile_path)
+        low = conanfile_content.lower()
+        conf = "def configure(self):"
+        conf2 = "del self.settings.compiler.libcxx"
+        return conf in low and conf2 in low
+
     @run_test("KB-H011", output)
     def test(out):
         if not _is_recipe_header_only(conanfile):
             cpp_extensions = ["cc", "cpp", "cxx", "c++m", "cppm", "cxxm", "h++", "hh", "hxx", "hpp"]
             c_extensions = ["c", "h"]
 
-            def _is_removing_libcxx():
-                conanfile_content = tools.load(conanfile_path)
-                low = conanfile_content.lower()
-                conf = "def configure(self):"
-                conf2 = "del self.settings.compiler.libcxx"
-                return conf in low and conf2 in low
-
             if not _is_removing_libcxx() \
                     and not _get_files_with_extensions(conanfile.source_folder, cpp_extensions) \
                     and _get_files_with_extensions(conanfile.source_folder, c_extensions):
                 out.error(
                         "Can't detect C++ source files but recipe does not remove 'compiler.libcxx'")
+
+    @run_test("KB-H022", output)
+    def test(out):
+
+        def _is_removing_cppstd():
+            conanfile_content = tools.load(conanfile_path)
+            low = conanfile_content.lower()
+            conf = "def configure(self):"
+            conf2 = "del self.settings.compiler.cppstd"
+            return conf in low and conf2 in low
+
+        if _is_removing_libcxx() and not _is_removing_cppstd():
+            out.error("Both 'compiler.libcxx' and 'compiler.cppstd' should be removed for C projects")
 
 
 @raise_if_error_output

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -114,3 +114,57 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [PACKAGE LICENSE (KB-H012)] No 'licenses' folder found in package", output)
         self.assertIn("[DEFAULT PACKAGE LAYOUT (KB-H013)] OK", output)
         self.assertIn("[SHARED ARTIFACTS (KB-H015)] OK", output)
+
+    def test_conanfile_cppstd(self):
+        content = textwrap.dedent("""\
+        from conans import ConanFile
+
+        class AConan(ConanFile):
+            url = "fake_url.com"
+            license = "fake_license"
+            description = "whatever"
+            exports_sources = "header.h"
+            settings = "os", "compiler", "arch", "build_type"
+
+            def configure(self):
+                {configure}
+
+            def package(self):
+                self.copy("*", dst="include")
+        """)
+
+        tools.save('conanfile.py', content=content.format(
+                   configure="del self.settings.compiler.libcxx"))
+        output = self.conan(['create', '.', 'name/version@user/test'])
+
+        self.assertIn("[RECIPE METADATA (KB-H003)] OK", output)
+        self.assertIn("[HEADER_ONLY, NO COPY SOURCE (KB-H005)] OK", output)
+        self.assertIn("[FPIC OPTION (KB-H006)] OK", output)
+        self.assertIn("[FPIC MANAGEMENT (KB-H007)] 'fPIC' option not found", output)
+        self.assertIn("[VERSION RANGES (KB-H008)] OK", output)
+        self.assertIn("[LIBCXX MANAGEMENT (KB-H011)] OK", output)
+        self.assertIn("ERROR: [MATCHING CONFIGURATION (KB-H014)] Empty package", output)
+        self.assertIn("ERROR: [MATCHING CONFIGURATION (KB-H014)] Packaged artifacts does not match", output)
+        self.assertIn("ERROR: [PACKAGE LICENSE (KB-H012)] No 'licenses' folder found in package", output)
+        self.assertIn("[DEFAULT PACKAGE LAYOUT (KB-H013)] OK", output)
+        self.assertIn("[SHARED ARTIFACTS (KB-H015)] OK", output)
+        self.assertIn("ERROR: [CPPSTD MANAGEMENT (KB-H022)] Both 'compiler.libcxx' and " \
+                      "'compiler.cppstd' should be removed for C projects", output)
+
+        tools.save('conanfile.py', content=content.format(configure="""
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd"""))
+        output = self.conan(['create', '.', 'name/version@user/test'])
+
+        self.assertIn("[RECIPE METADATA (KB-H003)] OK", output)
+        self.assertIn("[HEADER_ONLY, NO COPY SOURCE (KB-H005)] OK", output)
+        self.assertIn("[FPIC OPTION (KB-H006)] OK", output)
+        self.assertIn("[FPIC MANAGEMENT (KB-H007)] 'fPIC' option not found", output)
+        self.assertIn("[VERSION RANGES (KB-H008)] OK", output)
+        self.assertIn("[LIBCXX MANAGEMENT (KB-H011)] OK", output)
+        self.assertIn("ERROR: [MATCHING CONFIGURATION (KB-H014)] Empty package", output)
+        self.assertIn("ERROR: [MATCHING CONFIGURATION (KB-H014)] Packaged artifacts does not match", output)
+        self.assertIn("ERROR: [PACKAGE LICENSE (KB-H012)] No 'licenses' folder found in package", output)
+        self.assertIn("[DEFAULT PACKAGE LAYOUT (KB-H013)] OK", output)
+        self.assertIn("[SHARED ARTIFACTS (KB-H015)] OK", output)
+        self.assertIn("[CPPSTD MANAGEMENT (KB-H022)] OK", output)

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -123,7 +123,7 @@ class ConanCenterTests(ConanClientTestCase):
             url = "fake_url.com"
             license = "fake_license"
             description = "whatever"
-            exports_sources = "header.h"
+            exports_sources = "header.h", "test.c"
             settings = "os", "compiler", "arch", "build_type"
 
             def configure(self):
@@ -133,38 +133,18 @@ class ConanCenterTests(ConanClientTestCase):
                 self.copy("*", dst="include")
         """)
 
+        tools.save('test.c', content="#define FOO 1")
         tools.save('conanfile.py', content=content.format(
-                   configure="del self.settings.compiler.libcxx"))
+                   configure="pass"))
         output = self.conan(['create', '.', 'name/version@user/test'])
-
-        self.assertIn("[RECIPE METADATA (KB-H003)] OK", output)
-        self.assertIn("[HEADER_ONLY, NO COPY SOURCE (KB-H005)] OK", output)
-        self.assertIn("[FPIC OPTION (KB-H006)] OK", output)
-        self.assertIn("[FPIC MANAGEMENT (KB-H007)] 'fPIC' option not found", output)
-        self.assertIn("[VERSION RANGES (KB-H008)] OK", output)
-        self.assertIn("[LIBCXX MANAGEMENT (KB-H011)] OK", output)
-        self.assertIn("ERROR: [MATCHING CONFIGURATION (KB-H014)] Empty package", output)
-        self.assertIn("ERROR: [MATCHING CONFIGURATION (KB-H014)] Packaged artifacts does not match", output)
-        self.assertIn("ERROR: [PACKAGE LICENSE (KB-H012)] No 'licenses' folder found in package", output)
-        self.assertIn("[DEFAULT PACKAGE LAYOUT (KB-H013)] OK", output)
-        self.assertIn("[SHARED ARTIFACTS (KB-H015)] OK", output)
-        self.assertIn("ERROR: [CPPSTD MANAGEMENT (KB-H022)] Both 'compiler.libcxx' and " \
-                      "'compiler.cppstd' should be removed for C projects", output)
+        self.assertIn("ERROR: [LIBCXX MANAGEMENT (KB-H011)] Can't detect C++ source files but " \
+                      "recipe does not remove 'self.settings.compiler.libcxx'", output)
+        self.assertIn("ERROR: [CPPSTD MANAGEMENT (KB-H022)] Can't detect C++ source files but " \
+                      "recipe does not remove 'self.settings.compiler.cppstd'", output)
 
         tools.save('conanfile.py', content=content.format(configure="""
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd"""))
         output = self.conan(['create', '.', 'name/version@user/test'])
-
-        self.assertIn("[RECIPE METADATA (KB-H003)] OK", output)
-        self.assertIn("[HEADER_ONLY, NO COPY SOURCE (KB-H005)] OK", output)
-        self.assertIn("[FPIC OPTION (KB-H006)] OK", output)
-        self.assertIn("[FPIC MANAGEMENT (KB-H007)] 'fPIC' option not found", output)
-        self.assertIn("[VERSION RANGES (KB-H008)] OK", output)
         self.assertIn("[LIBCXX MANAGEMENT (KB-H011)] OK", output)
-        self.assertIn("ERROR: [MATCHING CONFIGURATION (KB-H014)] Empty package", output)
-        self.assertIn("ERROR: [MATCHING CONFIGURATION (KB-H014)] Packaged artifacts does not match", output)
-        self.assertIn("ERROR: [PACKAGE LICENSE (KB-H012)] No 'licenses' folder found in package", output)
-        self.assertIn("[DEFAULT PACKAGE LAYOUT (KB-H013)] OK", output)
-        self.assertIn("[SHARED ARTIFACTS (KB-H015)] OK", output)
         self.assertIn("[CPPSTD MANAGEMENT (KB-H022)] OK", output)


### PR DESCRIPTION
- Both libcxx and cppstd should be removed when is a recipe for C project only.

closes #89 
Wiki:

#### **<a name="KB-H022">#KB-H022</a>: "CPPSTD MANAGEMENT"**

If the library is detected as a pure C library (sources doesn't conatain any file with the following extensions: ["cc", "cpp", "cxx", "c++m", "cppm", "cxxm", "h++", "hh", "hxx", "hpp"]) then it has to remove the `compiler.cppstd` subsetting, because the cpp standard library shouldn't affect the binary ID:

```python
class SomeRecipe(ConanFile):
    ...

    def configure(self):
        del self.settings.compiler.cppstd
```