### PR TITLE
Don't allow to export licenses

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -25,7 +25,8 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H018": "LIBTOOL FILES PRESENCE",
              "KB-H019": "CMAKE FILE NOT IN BUILD FOLDERS",
              "KB-H020": "PC-FILES",
-             "KB-H021": "MS RUNTIME FILES"}
+             "KB-H021": "MS RUNTIME FILES",
+             "KB-H023": "EXPORT RECIPE"}
 
 
 class _HooksOutputErrorCollector(object):
@@ -188,6 +189,20 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
         if total_size_kb > max_folder_size:
             out.error("The size of your recipe folder ({} KB) is larger than the maximum allowed"
                       " size ({}KB).".format(total_size_kb, max_folder_size))
+
+    @run_test("KB-H023", output)
+    def test(out):
+        for attr_it in ["exports", "exports_sources"]:
+            exports = getattr(conanfile, attr_it, None)
+            out.info("exports: {}".format(exports))
+            if exports is None:
+                continue
+            exports = [exports] if isinstance(exports, str) else exports
+            for exports_it in exports:
+                for license_it in ["copying", "license", "copyright"]:
+                    if license_it in exports_it.lower():
+                        out.error("This recipe is exporting a license file. "
+                                  "Remove %s from `%s`" % (exports_it, attr_it))
 
 
 @raise_if_error_output

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -360,7 +360,7 @@ def post_package_info(output, conanfile, reference, **kwargs):
 
         if files_missplaced:
             out.error("The *.cmake files have to be placed in a folder declared as "
-                      "`cpp_info.buildirs`. Currently folders declared: {}".format(build_dirs))
+                      "`cpp_info.builddirs`. Currently folders declared: {}".format(build_dirs))
             out.error("Found files:\n{}".format("\n".join(files_missplaced)))
 
 

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -67,6 +67,7 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [PACKAGE LICENSE (KB-H012)] No 'licenses' folder found in package", output)
         self.assertIn("[DEFAULT PACKAGE LAYOUT (KB-H013)] OK", output)
         self.assertIn("[SHARED ARTIFACTS (KB-H015)] OK", output)
+        self.assertIn("[EXPORT RECIPE (KB-H023)] OK", output)
 
     def test_conanfile_header_only(self):
         tools.save('conanfile.py', content=self.conanfile_header_only)
@@ -83,6 +84,7 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [PACKAGE LICENSE (KB-H012)] No 'licenses' folder found in package", output)
         self.assertIn("[DEFAULT PACKAGE LAYOUT (KB-H013)] OK", output)
         self.assertIn("[SHARED ARTIFACTS (KB-H015)] OK", output)
+        self.assertIn("[EXPORT RECIPE (KB-H023)] OK", output)
 
     def test_conanfile_header_only_with_settings(self):
         tools.save('conanfile.py', content=self.conanfile_header_only_with_settings)
@@ -98,6 +100,7 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [PACKAGE LICENSE (KB-H012)] No 'licenses' folder found in package", output)
         self.assertIn("[DEFAULT PACKAGE LAYOUT (KB-H013)] OK", output)
         self.assertIn("[SHARED ARTIFACTS (KB-H015)] OK", output)
+        self.assertIn("[EXPORT RECIPE (KB-H023)] OK", output)
 
     def test_conanfile_installer(self):
         tools.save('conanfile.py', content=self.conanfile_installer)
@@ -114,3 +117,23 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [PACKAGE LICENSE (KB-H012)] No 'licenses' folder found in package", output)
         self.assertIn("[DEFAULT PACKAGE LAYOUT (KB-H013)] OK", output)
         self.assertIn("[SHARED ARTIFACTS (KB-H015)] OK", output)
+        self.assertIn("[EXPORT RECIPE (KB-H023)] OK", output)
+
+    def test_exports_licenses(self):
+        tools.save('conanfile.py',
+                   content=self.conanfile_base.format(placeholder='exports = "LICENSE"'))
+        output = self.conan(['create', '.', 'name/version@name/test'])
+        self.assertIn("ERROR: [EXPORT RECIPE (KB-H023)] This recipe is exporting a license file." \
+                      " Remove LICENSE from `exports`", output)
+
+        tools.save('conanfile.py',
+                   content=self.conanfile_base.format(placeholder='exports_sources = "LICENSE"'))
+        output = self.conan(['create', '.', 'name/version@name/test'])
+        self.assertIn("ERROR: [EXPORT RECIPE (KB-H023)] This recipe is exporting a license file." \
+                      " Remove LICENSE from `exports_sources`", output)
+
+        tools.save('conanfile.py',
+                   content=self.conanfile_base.format(placeholder='exports = ["foobar", "COPYING.md"]'))
+        output = self.conan(['create', '.', 'name/version@name/test'])
+        self.assertIn("ERROR: [EXPORT RECIPE (KB-H023)] This recipe is exporting a license file." \
+                      " Remove COPYING.md from `exports`", output)


### PR DESCRIPTION
Both exports and exports_sources should not provide a LICENSE file. It should be collected from the downloaded files.

closes https://github.com/conan-io/hooks/issues/85
Wiki:

#### **<a name="KB-H023">#KB-H023</a>: "EXPORT LICENSE"**

Recipe package should not contain a license file, as all recipes are under the same license type.

```python
class SomeRecipe(ConanFile):
    ...

    exports = "LICENSE.md" # not allowed
```

There is a complete explanation on [FAQ](https://github.com/conan-io/conan-center-index/wiki/FAQ#should-recipes-export-a-recipes-license).