### PR TITLE
Add homepage attribute as mandatory & topics as recommended

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -125,7 +125,7 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
 
     @run_test("KB-H003", output)
     def test(out):
-        for field in ["url", "license", "description"]:
+        for field in ["url", "license", "description", "topics", "homepage", "author"]:
             field_value = getattr(conanfile, field, None)
             if not field_value:
                 out.error("Conanfile doesn't have '%s' attribute. " % field)

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -125,10 +125,14 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
 
     @run_test("KB-H003", output)
     def test(out):
-        for field in ["url", "license", "description", "topics", "homepage", "author"]:
-            field_value = getattr(conanfile, field, None)
-            if not field_value:
-                out.error("Conanfile doesn't have '%s' attribute. " % field)
+        def _message_attr(attributes, out_method):
+            for field in attributes:
+                field_value = getattr(conanfile, field, None)
+                if not field_value:
+                    out_method("Conanfile doesn't have '%s' attribute. " % field)
+
+        _message_attr(["url", "license", "description", "homepage"], out.error)
+        _message_attr(["topics"], out.warn)
 
     @run_test("KB-H005", output)
     def test(out):

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -360,7 +360,7 @@ def post_package_info(output, conanfile, reference, **kwargs):
 
         if files_missplaced:
             out.error("The *.cmake files have to be placed in a folder declared as "
-                      "`cpp_info.buildirs`. Currently folders declared: {}".format(build_dirs))
+                      "`cpp_info.builddirs`. Currently folders declared: {}".format(build_dirs))
             out.error("Found files:\n{}".format("\n".join(files_missplaced)))
 
 

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -16,6 +16,9 @@ class ConanCenterTests(ConanClientTestCase):
             url = "fake_url.com"
             license = "fake_license"
             description = "whatever"
+            author = "unknown"
+            topics = ("foo", "bar", "qux")
+            homepage = "homepage.com"
             exports_sources = "header.h"
             {placeholder}
 
@@ -29,6 +32,9 @@ class ConanCenterTests(ConanClientTestCase):
             url = "fake_url.com"
             license = "fake_license"
             description = "whatever"
+            author = "unknown"
+            topics = ("foo", "bar", "qux")
+            homepage = "homepage.com"
             exports_sources = "header.h"
             settings = "os", "compiler", "arch", "build_type"
 

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -16,8 +16,6 @@ class ConanCenterTests(ConanClientTestCase):
             url = "fake_url.com"
             license = "fake_license"
             description = "whatever"
-            author = "unknown"
-            topics = ("foo", "bar", "qux")
             homepage = "homepage.com"
             exports_sources = "header.h"
             {placeholder}
@@ -32,8 +30,6 @@ class ConanCenterTests(ConanClientTestCase):
             url = "fake_url.com"
             license = "fake_license"
             description = "whatever"
-            author = "unknown"
-            topics = ("foo", "bar", "qux")
             homepage = "homepage.com"
             exports_sources = "header.h"
             settings = "os", "compiler", "arch", "build_type"

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -162,6 +162,22 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("[LIBCXX MANAGEMENT (KB-H011)] OK", output)
         self.assertIn("[CPPSTD MANAGEMENT (KB-H022)] OK", output)
 
+    def test_missing_attributes(self):
+        conanfile = textwrap.dedent("""\
+        from conans import ConanFile
+        class AConan(ConanFile):
+            homepage = "homepage.com"
+            exports_sources = "header.h"
+            def package(self):
+                self.copy("*", dst="include")
+        """)
+        tools.save('conanfile.py', content=conanfile)
+        output = self.conan(['create', '.', 'name/version@user/test'])
+        self.assertIn("ERROR: [RECIPE METADATA (KB-H003)] Conanfile doesn't have 'url' attribute.", output)
+        self.assertIn("ERROR: [RECIPE METADATA (KB-H003)] Conanfile doesn't have 'description' attribute.", output)
+        self.assertIn("WARN: [RECIPE METADATA (KB-H003)] Conanfile doesn't have 'topics' attribute.", output)
+        self.assertNotIn("[RECIPE METADATA (KB-H003)] OK", output)
+
     def test_conanfile_fpic(self):
         tools.save('conanfile.py', content=self.conanfile_fpic)
         output = self.conan(['create', '.', 'fpic/version@conan/test'])

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -120,3 +120,21 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [PACKAGE LICENSE (KB-H012)] No 'licenses' folder found in package", output)
         self.assertIn("[DEFAULT PACKAGE LAYOUT (KB-H013)] OK", output)
         self.assertIn("[SHARED ARTIFACTS (KB-H015)] OK", output)
+
+    def test_missing_attributes(self):
+        conanfile = textwrap.dedent("""\
+        from conans import ConanFile
+
+        class AConan(ConanFile):
+            homepage = "homepage.com"
+            exports_sources = "header.h"
+
+            def package(self):
+                self.copy("*", dst="include")
+        """)
+        tools.save('conanfile.py', content=conanfile)
+        output = self.conan(['create', '.', 'name/version@user/test'])
+        self.assertIn("ERROR: [RECIPE METADATA (KB-H003)] Conanfile doesn't have 'url' attribute.", output)
+        self.assertIn("ERROR: [RECIPE METADATA (KB-H003)] Conanfile doesn't have 'description' attribute.", output)
+        self.assertIn("WARN: [RECIPE METADATA (KB-H003)] Conanfile doesn't have 'topics' attribute.", output)
+        self.assertNotIn("[RECIPE METADATA (KB-H003)] OK", output)


### PR DESCRIPTION
- Add `homepage` attribute as mandatory & `topics` as recommended

closes #88
Wiki:

#### **<a name="KB-H003">#KB-H003</a>: "RECIPE METADATA"**

The recipe has to declare the following fields: [url](https://docs.conan.io/en/latest/reference/conanfile/attributes.html#url), [license](https://docs.conan.io/en/latest/reference/conanfile/attributes.html#license) , [description](https://docs.conan.io/en/latest/reference/conanfile/attributes.html#description), [homepage](https://docs.conan.io/en/latest/reference/conanfile/attributes.html#homepage). Also, we recommend adding [topics](https://docs.conan.io/en/latest/reference/conanfile/attributes.html#topics)