### PR TITLE
Validate RunEnvironment on test_package

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -25,7 +25,8 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H018": "LIBTOOL FILES PRESENCE",
              "KB-H019": "CMAKE FILE NOT IN BUILD FOLDERS",
              "KB-H020": "PC-FILES",
-             "KB-H021": "MS RUNTIME FILES"}
+             "KB-H021": "MS RUNTIME FILES",
+             "KB-H024": "TEST PACKAGE - RUN ENVIRONMENT"}
 
 
 class _HooksOutputErrorCollector(object):
@@ -188,6 +189,19 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
         if total_size_kb > max_folder_size:
             out.error("The size of your recipe folder ({} KB) is larger than the maximum allowed"
                       " size ({}KB).".format(total_size_kb, max_folder_size))
+
+    @run_test("KB-H024", output)
+    def test(out):
+        dir_path = os.path.dirname(conanfile_path)
+        test_package_path = os.path.join(dir_path, "test_package")
+        if not os.path.exists(test_package_path):
+            out.warn("There is no `test_package` for this recipe")
+            return
+
+        test_package_conanfile = tools.load(os.path.join(test_package_path, "conanfile.py"))
+        if "RunEnvironment" in test_package_conanfile:
+            out.error("`RunEnvironment is deprecated. "
+                      "Use `self.run(command, run_environment=True)` instead")
 
 
 @raise_if_error_output

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -67,6 +67,8 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [PACKAGE LICENSE (KB-H012)] No 'licenses' folder found in package", output)
         self.assertIn("[DEFAULT PACKAGE LAYOUT (KB-H013)] OK", output)
         self.assertIn("[SHARED ARTIFACTS (KB-H015)] OK", output)
+        self.assertIn("WARN: [TEST PACKAGE - RUN ENVIRONMENT (KB-H024)] There is no "
+                      "`test_package` for this recipe", output)
 
     def test_conanfile_header_only(self):
         tools.save('conanfile.py', content=self.conanfile_header_only)
@@ -83,6 +85,8 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [PACKAGE LICENSE (KB-H012)] No 'licenses' folder found in package", output)
         self.assertIn("[DEFAULT PACKAGE LAYOUT (KB-H013)] OK", output)
         self.assertIn("[SHARED ARTIFACTS (KB-H015)] OK", output)
+        self.assertIn("WARN: [TEST PACKAGE - RUN ENVIRONMENT (KB-H024)] There is no "
+                      "`test_package` for this recipe", output)
 
     def test_conanfile_header_only_with_settings(self):
         tools.save('conanfile.py', content=self.conanfile_header_only_with_settings)
@@ -98,6 +102,8 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [PACKAGE LICENSE (KB-H012)] No 'licenses' folder found in package", output)
         self.assertIn("[DEFAULT PACKAGE LAYOUT (KB-H013)] OK", output)
         self.assertIn("[SHARED ARTIFACTS (KB-H015)] OK", output)
+        self.assertIn("WARN: [TEST PACKAGE - RUN ENVIRONMENT (KB-H024)] There is no "
+                      "`test_package` for this recipe", output)
 
     def test_conanfile_installer(self):
         tools.save('conanfile.py', content=self.conanfile_installer)
@@ -114,3 +120,38 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [PACKAGE LICENSE (KB-H012)] No 'licenses' folder found in package", output)
         self.assertIn("[DEFAULT PACKAGE LAYOUT (KB-H013)] OK", output)
         self.assertIn("[SHARED ARTIFACTS (KB-H015)] OK", output)
+        self.assertIn("WARN: [TEST PACKAGE - RUN ENVIRONMENT (KB-H024)] There is no "
+                      "`test_package` for this recipe", output)
+
+    def test_run_environment_test_package(self):
+        conanfile_tp = textwrap.dedent("""\
+        from conans import ConanFile, RunEnvironment, tools
+
+        class TestConan(ConanFile):
+            settings = "os", "arch"
+
+            def test(self):
+                env_build = RunEnvironment(self)
+                with tools.environment_append(env_build.vars):
+                    self.run("echo bar")
+        """)
+        tools.save('test_package/conanfile.py', content=conanfile_tp)
+        tools.save('conanfile.py', content=self.conanfile)
+        output = self.conan(['create', '.', 'name/version@user/test'])
+        self.assertIn("ERROR: [TEST PACKAGE - RUN ENVIRONMENT (KB-H024)] `RunEnvironment is "
+                      "deprecated. Use `self.run(command, run_environment=True)` instead", output)
+
+        conanfile_tp = textwrap.dedent("""\
+        from conans import ConanFile, tools
+
+        class TestConan(ConanFile):
+            settings = "os", "arch"
+
+            def test(self):
+                self.run("echo bar", run_environment=True)
+        """)
+
+        tools.save('test_package/conanfile.py', content=conanfile_tp)
+        tools.save('conanfile.py', content=self.conanfile)
+        output = self.conan(['create', '.', 'name/version@user/test'])
+        self.assertIn("[TEST PACKAGE - RUN ENVIRONMENT (KB-H024)] OK", output)


### PR DESCRIPTION
`RunEnvironment` is deprecated and should be replaced by `run_environment=True`

closes https://github.com/conan-io/hooks/issues/86