### PR TITLE
Validate version attribute for gen folder

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -25,7 +25,8 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H018": "LIBTOOL FILES PRESENCE",
              "KB-H019": "CMAKE FILE NOT IN BUILD FOLDERS",
              "KB-H020": "PC-FILES",
-             "KB-H021": "MS RUNTIME FILES"}
+             "KB-H021": "MS RUNTIME FILES",
+             "KB-H026": "VERSION ATTRIBUTE",}
 
 
 class _HooksOutputErrorCollector(object):
@@ -188,6 +189,14 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
         if total_size_kb > max_folder_size:
             out.error("The size of your recipe folder ({} KB) is larger than the maximum allowed"
                       " size ({}KB).".format(total_size_kb, max_folder_size))
+
+    @run_test("KB-H026", output)
+    def test(out):
+        dir_path = os.path.basename(os.path.dirname(conanfile_path))
+        version = getattr(conanfile, "version", None)
+        if dir_path.lower() == "all" and version:
+            out.error("The recipe folder `all` is generic, but your recipe contains the " \
+                      "attribute version. Remove the attribute `version` from the recipe")
 
 
 @raise_if_error_output

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -67,6 +67,7 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [PACKAGE LICENSE (KB-H012)] No 'licenses' folder found in package", output)
         self.assertIn("[DEFAULT PACKAGE LAYOUT (KB-H013)] OK", output)
         self.assertIn("[SHARED ARTIFACTS (KB-H015)] OK", output)
+        self.assertIn("[VERSION ATTRIBUTE (KB-H026)] OK", output)
 
     def test_conanfile_header_only(self):
         tools.save('conanfile.py', content=self.conanfile_header_only)
@@ -83,6 +84,7 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [PACKAGE LICENSE (KB-H012)] No 'licenses' folder found in package", output)
         self.assertIn("[DEFAULT PACKAGE LAYOUT (KB-H013)] OK", output)
         self.assertIn("[SHARED ARTIFACTS (KB-H015)] OK", output)
+        self.assertIn("[VERSION ATTRIBUTE (KB-H026)] OK", output)
 
     def test_conanfile_header_only_with_settings(self):
         tools.save('conanfile.py', content=self.conanfile_header_only_with_settings)
@@ -98,6 +100,7 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [PACKAGE LICENSE (KB-H012)] No 'licenses' folder found in package", output)
         self.assertIn("[DEFAULT PACKAGE LAYOUT (KB-H013)] OK", output)
         self.assertIn("[SHARED ARTIFACTS (KB-H015)] OK", output)
+        self.assertIn("[VERSION ATTRIBUTE (KB-H026)] OK", output)
 
     def test_conanfile_installer(self):
         tools.save('conanfile.py', content=self.conanfile_installer)
@@ -114,3 +117,11 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [PACKAGE LICENSE (KB-H012)] No 'licenses' folder found in package", output)
         self.assertIn("[DEFAULT PACKAGE LAYOUT (KB-H013)] OK", output)
         self.assertIn("[SHARED ARTIFACTS (KB-H015)] OK", output)
+        self.assertIn("[VERSION ATTRIBUTE (KB-H026)] OK", output)
+
+    def test_version_folder_name(self):
+        tools.save('all/conanfile.py', content=self.conanfile)
+        output = self.conan(['create', 'all', 'name/version@user/test'])
+        self.assertIn("ERROR: [VERSION ATTRIBUTE (KB-H026)] The recipe folder `all` is generic, " \
+                      "but your recipe contains the attribute version. Remove the attribute " \
+                      "`version` from the recipe", output)


### PR DESCRIPTION
When building generic recipe, the attribute should not be declared in the recipe.

closes #83 
