### PR TITLE
#87 Vaidate CCI URL

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -194,8 +194,8 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
 
     @run_test("KB-H027", output)
     def test(out):
-        url = getattr(conanfile, "url", "")
-        if not url.startswith("https://github.com/conan-io/conan-center-index"):
+        url = getattr(conanfile, "url", None)
+        if url and not url.startswith("https://github.com/conan-io/conan-center-index"):
             out.error("The attribute `url` should point to CCI address: " \
                       "https://github.com/conan-io/conan-center-index")
 

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -25,7 +25,8 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H018": "LIBTOOL FILES PRESENCE",
              "KB-H019": "CMAKE FILE NOT IN BUILD FOLDERS",
              "KB-H020": "PC-FILES",
-             "KB-H021": "MS RUNTIME FILES"}
+             "KB-H021": "MS RUNTIME FILES",
+             "KB-H027": "CCI URL"}
 
 
 class _HooksOutputErrorCollector(object):
@@ -188,6 +189,13 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
         if total_size_kb > max_folder_size:
             out.error("The size of your recipe folder ({} KB) is larger than the maximum allowed"
                       " size ({}KB).".format(total_size_kb, max_folder_size))
+
+    @run_test("KB-H027", output)
+    def test(out):
+        url = getattr(conanfile, "url", None)
+        if url and "https://github.com/conan-io/conan-center-index" not in url:
+            out.error("The attribute `url` should point to CCI address: " \
+                      "https://github.com/conan-io/conan-center-index")
 
 
 @raise_if_error_output

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -26,7 +26,7 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H019": "CMAKE FILE NOT IN BUILD FOLDERS",
              "KB-H020": "PC-FILES",
              "KB-H021": "MS RUNTIME FILES",
-             "KB-H027": "CCI URL"}
+             "KB-H027": "CONAN CENTER INDEX URL"}
 
 
 class _HooksOutputErrorCollector(object):
@@ -192,8 +192,8 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
 
     @run_test("KB-H027", output)
     def test(out):
-        url = getattr(conanfile, "url", None)
-        if url and "https://github.com/conan-io/conan-center-index" not in url:
+        url = getattr(conanfile, "url", "")
+        if not url.startswith("https://github.com/conan-io/conan-center-index"):
             out.error("The attribute `url` should point to CCI address: " \
                       "https://github.com/conan-io/conan-center-index")
 

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -67,6 +67,8 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [PACKAGE LICENSE (KB-H012)] No 'licenses' folder found in package", output)
         self.assertIn("[DEFAULT PACKAGE LAYOUT (KB-H013)] OK", output)
         self.assertIn("[SHARED ARTIFACTS (KB-H015)] OK", output)
+        self.assertIn("ERROR: [CCI URL (KB-H027)] The attribute `url` should point to CCI " \
+                      "address: https://github.com/conan-io/conan-center-index", output)
 
     def test_conanfile_header_only(self):
         tools.save('conanfile.py', content=self.conanfile_header_only)
@@ -114,3 +116,20 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [PACKAGE LICENSE (KB-H012)] No 'licenses' folder found in package", output)
         self.assertIn("[DEFAULT PACKAGE LAYOUT (KB-H013)] OK", output)
         self.assertIn("[SHARED ARTIFACTS (KB-H015)] OK", output)
+
+    def test_cci_url(self):
+        conanfile = textwrap.dedent("""\
+        from conans import ConanFile
+
+        class AConan(ConanFile):
+            url = "https://github.com/conan-io/conan-center-index"
+            license = "fake_license"
+            description = "whatever"
+            exports_sources = "header.h"
+
+            def package(self):
+                self.copy("*", dst="include")
+        """)
+        tools.save('conanfile.py', content=conanfile)
+        output = self.conan(['create', '.', 'name/version@jgsogo/test'])
+        self.assertIn("[CCI URL (KB-H027)] OK", output)

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -183,5 +183,3 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("FPIC OPTION (KB-H006)] OK", output)
         self.assertNotIn("[FPIC MANAGEMENT (KB-H007)] 'fPIC' option not found", output)
         self.assertIn("[FPIC MANAGEMENT (KB-H007)] 'fPIC' option not managed correctly.", output)
-
-

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -67,8 +67,8 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [PACKAGE LICENSE (KB-H012)] No 'licenses' folder found in package", output)
         self.assertIn("[DEFAULT PACKAGE LAYOUT (KB-H013)] OK", output)
         self.assertIn("[SHARED ARTIFACTS (KB-H015)] OK", output)
-        self.assertIn("ERROR: [CCI URL (KB-H027)] The attribute `url` should point to CCI " \
-                      "address: https://github.com/conan-io/conan-center-index", output)
+        self.assertIn("ERROR: [CONAN CENTER INDEX URL (KB-H027)] The attribute `url` should " \
+                      "point to CCI address: https://github.com/conan-io/conan-center-index", output)
 
     def test_conanfile_header_only(self):
         tools.save('conanfile.py', content=self.conanfile_header_only)
@@ -132,4 +132,4 @@ class ConanCenterTests(ConanClientTestCase):
         """)
         tools.save('conanfile.py', content=conanfile)
         output = self.conan(['create', '.', 'name/version@jgsogo/test'])
-        self.assertIn("[CCI URL (KB-H027)] OK", output)
+        self.assertIn("[CONAN CENTER INDEX URL (KB-H027)] OK", output)


### PR DESCRIPTION
Since CCI is the new central repo, all URLs should be the same.

closes #87 
Wiki:

#### **<a name="KB-H027">#KB-H027</a>: "CONAN CENTER INDEX URL"**

The attribute `url` should point to the address where the recipe is located.
The current Conan Center Index address is https://github.com/conan-io/conan-center-index