### PR TITLE
Check for CMake minimum version

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -202,14 +202,12 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
                         cmake_path = os.path.join(root, filename)
                         cmake_content = tools.load(cmake_path).lower()
                         if not "cmake_minimum_required(version" in cmake_content:
+                            file_path = os.path.join(os.path.relpath(root), filename)
                             out.error("The CMake file '%s' must contain a minimum version " \
-                                      "declared" % filename)
+                                      "declared" % file_path)
 
         dir_path = os.path.dirname(conanfile_path)
-        test_package_path = os.path.join(dir_path, "test_package")
         _find_cmake_minimum(dir_path)
-        if os.path.exists(test_package_path):
-            _find_cmake_minimum(test_package_path)
 
 
 @raise_if_error_output

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -204,7 +204,8 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
                         if not "cmake_minimum_required(version" in cmake_content:
                             file_path = os.path.join(os.path.relpath(root), filename)
                             out.error("The CMake file '%s' must contain a minimum version " \
-                                      "declared" % file_path)
+                                      "declared (e.g. cmake_minimum_required(VERSION 3.1.2))" %
+                                      file_path)
 
         dir_path = os.path.dirname(conanfile_path)
         _find_cmake_minimum(dir_path)

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -155,7 +155,8 @@ class ConanCenterTests(ConanClientTestCase):
         tools.save('CMakeLists.txt', content="project(foo CXX)")
         output = self.conan(['create', '.', 'cmake/version@user/test'])
         self.assertIn("ERROR: [CMAKE MINIMUM VERSION (KB-H028)] The CMake file './CMakeLists.txt' " \
-                      "must contain a minimum version declared", output)
+                      "must contain a minimum version declared " \
+                      "(e.g. cmake_minimum_required(VERSION 3.1.2))", output)
 
         tools.save('CMakeLists.txt', content="cmake_minimum_required(VERSION 2.8.11)")
         output = self.conan(['create', '.', 'cmake/version@user/test'])
@@ -164,7 +165,8 @@ class ConanCenterTests(ConanClientTestCase):
         tools.save('test_package/CMakeLists.txt', content="project(foo CXX)")
         output = self.conan(['create', '.', 'cmake/version@user/test'])
         self.assertIn("ERROR: [CMAKE MINIMUM VERSION (KB-H028)] The CMake file 'test_package/CMakeLists.txt' " \
-                      "must contain a minimum version declared", output)
+                      "must contain a minimum version declared " \
+                      "(e.g. cmake_minimum_required(VERSION 3.1.2))", output)
 
         tools.save('test_package/CMakeLists.txt', content="cmake_minimum_required(VERSION 2.8.11)")
         output = self.conan(['create', '.', 'cmake/version@user/test'])

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -154,7 +154,7 @@ class ConanCenterTests(ConanClientTestCase):
         tools.save('conanfile.py', content=conanfile)
         tools.save('CMakeLists.txt', content="project(foo CXX)")
         output = self.conan(['create', '.', 'cmake/version@user/test'])
-        self.assertIn("ERROR: [CMAKE MINIMUM VERSION (KB-H028)] The CMake file 'CMakeLists.txt' " \
+        self.assertIn("ERROR: [CMAKE MINIMUM VERSION (KB-H028)] The CMake file './CMakeLists.txt' " \
                       "must contain a minimum version declared", output)
 
         tools.save('CMakeLists.txt', content="cmake_minimum_required(VERSION 2.8.11)")
@@ -163,7 +163,7 @@ class ConanCenterTests(ConanClientTestCase):
 
         tools.save('test_package/CMakeLists.txt', content="project(foo CXX)")
         output = self.conan(['create', '.', 'cmake/version@user/test'])
-        self.assertIn("ERROR: [CMAKE MINIMUM VERSION (KB-H028)] The CMake file 'CMakeLists.txt' " \
+        self.assertIn("ERROR: [CMAKE MINIMUM VERSION (KB-H028)] The CMake file 'test_package/CMakeLists.txt' " \
                       "must contain a minimum version declared", output)
 
         tools.save('test_package/CMakeLists.txt', content="cmake_minimum_required(VERSION 2.8.11)")

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -387,3 +387,15 @@ class ConanCenterTests(ConanClientTestCase):
         tools.save('conanfile.py', content=conanfile)
         output = self.conan(['create', '.', 'name/version@jgsogo/test'])
         self.assertIn("[CONAN CENTER INDEX URL (KB-H027)] OK", output)
+
+    def test_cmake_minimum_verstion(self):
+        conanfile = self.conanfile_base.format(placeholder="exports_sources = \"CMakeLists.txt\"")
+        cmake = """project(test)
+        """
+        tools.save('conanfile.py', content=conanfile)
+        tools.save('CMakeLists.txt', content=cmake)
+        output = self.conan(['create', '.', 'name/version@jgsogo/test'])
+        path = os.path.join(".", "CMakeLists.txt")
+        self.assertIn("ERROR: [CMAKE MINIMUM VERSION (KB-H028)] The CMake file '%s' must contain a "
+                      "minimum version declared (e.g. cmake_minimum_required(VERSION 3.1.2))" % path,
+                      output)

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -78,6 +78,7 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [PACKAGE LICENSE (KB-H012)] No 'licenses' folder found in package", output)
         self.assertIn("[DEFAULT PACKAGE LAYOUT (KB-H013)] OK", output)
         self.assertIn("[SHARED ARTIFACTS (KB-H015)] OK", output)
+        self.assertIn("[CMAKE MINIMUM VERSION (KB-H028)] OK", output)
 
     def test_conanfile_header_only(self):
         tools.save('conanfile.py', content=self.conanfile_header_only)
@@ -94,6 +95,7 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [PACKAGE LICENSE (KB-H012)] No 'licenses' folder found in package", output)
         self.assertIn("[DEFAULT PACKAGE LAYOUT (KB-H013)] OK", output)
         self.assertIn("[SHARED ARTIFACTS (KB-H015)] OK", output)
+        self.assertIn("[CMAKE MINIMUM VERSION (KB-H028)] OK", output)
 
     def test_conanfile_header_only_with_settings(self):
         tools.save('conanfile.py', content=self.conanfile_header_only_with_settings)
@@ -109,6 +111,7 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [PACKAGE LICENSE (KB-H012)] No 'licenses' folder found in package", output)
         self.assertIn("[DEFAULT PACKAGE LAYOUT (KB-H013)] OK", output)
         self.assertIn("[SHARED ARTIFACTS (KB-H015)] OK", output)
+        self.assertIn("[CMAKE MINIMUM VERSION (KB-H028)] OK", output)
 
     def test_conanfile_installer(self):
         tools.save('conanfile.py', content=self.conanfile_installer)
@@ -125,6 +128,8 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [PACKAGE LICENSE (KB-H012)] No 'licenses' folder found in package", output)
         self.assertIn("[DEFAULT PACKAGE LAYOUT (KB-H013)] OK", output)
         self.assertIn("[SHARED ARTIFACTS (KB-H015)] OK", output)
+        self.assertIn("[CMAKE MINIMUM VERSION (KB-H028)] OK", output)
+
 
     def test_conanfile_fpic(self):
         tools.save('conanfile.py', content=self.conanfile_fpic)
@@ -132,3 +137,35 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("FPIC OPTION (KB-H006)] OK", output)
         self.assertNotIn("[FPIC MANAGEMENT (KB-H007)] 'fPIC' option not found", output)
         self.assertIn("[FPIC MANAGEMENT (KB-H007)] 'fPIC' option not managed correctly.", output)
+
+    def test_cmake_minimum_required(self):
+        conanfile = textwrap.dedent("""\
+        from conans import ConanFile
+
+        class AConan(ConanFile):
+            url = "fake_url.com"
+            license = "fake_license"
+            description = "whatever"
+            exports_sources = "CMakeLists.txt"
+
+            def package(self):
+                self.copy("CMakeLists.txt", dst="res")
+        """)
+        tools.save('conanfile.py', content=conanfile)
+        tools.save('CMakeLists.txt', content="project(foo CXX)")
+        output = self.conan(['create', '.', 'cmake/version@user/test'])
+        self.assertIn("ERROR: [CMAKE MINIMUM VERSION (KB-H028)] The CMake file 'CMakeLists.txt' " \
+                      "must contain a minimum version declared", output)
+
+        tools.save('CMakeLists.txt', content="cmake_minimum_required(VERSION 2.8.11)")
+        output = self.conan(['create', '.', 'cmake/version@user/test'])
+        self.assertIn("[CMAKE MINIMUM VERSION (KB-H028)] OK", output)
+
+        tools.save('test_package/CMakeLists.txt', content="project(foo CXX)")
+        output = self.conan(['create', '.', 'cmake/version@user/test'])
+        self.assertIn("ERROR: [CMAKE MINIMUM VERSION (KB-H028)] The CMake file 'CMakeLists.txt' " \
+                      "must contain a minimum version declared", output)
+
+        tools.save('test_package/CMakeLists.txt', content="cmake_minimum_required(VERSION 2.8.11)")
+        output = self.conan(['create', '.', 'cmake/version@user/test'])
+        self.assertIn("[CMAKE MINIMUM VERSION (KB-H028)] OK", output)

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -86,9 +86,9 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("[EXPORT LICENSE (KB-H023)] OK", output)
         self.assertIn("ERROR: [TEST PACKAGE FOLDER (KB-H024)] There is no 'test_package' for this "
                       "recipe", output)
+        self.assertIn("[META LINES (KB-H025)] OK", output)
         self.assertIn("ERROR: [CONAN CENTER INDEX URL (KB-H027)] The attribute 'url' should " \
                       "point to: https://github.com/conan-io/conan-center-index", output)
-        self.assertIn("[META LINES (KB-H025)] OK", output)
         self.assertIn("[CMAKE MINIMUM VERSION (KB-H028)] OK", output)
 
     def test_conanfile_header_only(self):
@@ -106,11 +106,11 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [PACKAGE LICENSE (KB-H012)] No 'licenses' folder found in package", output)
         self.assertIn("[DEFAULT PACKAGE LAYOUT (KB-H013)] OK", output)
         self.assertIn("[SHARED ARTIFACTS (KB-H015)] OK", output)
-        self.assertIn("[CMAKE MINIMUM VERSION (KB-H028)] OK", output)
         self.assertIn("[EXPORT LICENSE (KB-H023)] OK", output)
         self.assertIn("ERROR: [TEST PACKAGE FOLDER (KB-H024)] There is no 'test_package' for this "
                       "recipe", output)
         self.assertIn("[META LINES (KB-H025)] OK", output)
+        self.assertIn("[CMAKE MINIMUM VERSION (KB-H028)] OK", output)
 
     def test_conanfile_header_only_with_settings(self):
         tools.save('conanfile.py', content=self.conanfile_header_only_with_settings)
@@ -126,11 +126,11 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [PACKAGE LICENSE (KB-H012)] No 'licenses' folder found in package", output)
         self.assertIn("[DEFAULT PACKAGE LAYOUT (KB-H013)] OK", output)
         self.assertIn("[SHARED ARTIFACTS (KB-H015)] OK", output)
-        self.assertIn("[CMAKE MINIMUM VERSION (KB-H028)] OK", output)
         self.assertIn("[EXPORT LICENSE (KB-H023)] OK", output)
         self.assertIn("ERROR: [TEST PACKAGE FOLDER (KB-H024)] There is no 'test_package' for this "
                       "recipe", output)
         self.assertIn("[META LINES (KB-H025)] OK", output)
+        self.assertIn("[CMAKE MINIMUM VERSION (KB-H028)] OK", output)
 
     def test_conanfile_installer(self):
         tools.save('conanfile.py', content=self.conanfile_installer)


### PR DESCRIPTION
- Try to find CMake files and validate if it contains cmake_minimum_required(VERSION ...)
- As some projects use CMAKE_SOURCE_DIR, the recipe need to replace the cmake file by another one (e.g. CMakeOriginalLists.cmake), that's why I'm checking pattern instead of "CMakeLists.txt" directly

closes #99 
Wiki: 

#### **<a name="KB-H028">#KB-H028</a>: "CMAKE MINIMUM VERSION"**

All CMake files added to recipe package should contain a minimal version (Not necessarily 2.8.11, it can be any version) available in the file:

```cmake
# CMakeLists.txt
cmake_minimum_required(VERSION 2.8.11)
project(conanwrapper)

...
```

This requirement is also valid for the `test_package`.