### PR TITLE
Linter messages are considered an error

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -38,7 +38,8 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H028": "CMAKE MINIMUM VERSION",
              "KB-H029": "TEST PACKAGE - RUN ENVIRONMENT",
              "KB-H030": "CONANDATA.YML FORMAT",
-             "KB-H031": "CONANDATA.YML REDUCE"}
+             "KB-H031": "CONANDATA.YML REDUCE",
+            }
 
 
 class _HooksOutputErrorCollector(object):

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -30,6 +30,7 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H023": "EXPORT LICENSE",
              "KB-H024": "TEST PACKAGE FOLDER",
              "KB-H025": "META LINES",
+             "KB-H026": "LINTER WARNINGS",
              "KB-H027": "CONAN CENTER INDEX URL",
              "KB-H028": "CMAKE MINIMUM VERSION",
              "KB-H029": "TEST PACKAGE - RUN ENVIRONMENT"}
@@ -298,6 +299,13 @@ def pre_source(output, conanfile, conanfile_path, **kwargs):
             if not fixed_sources:
                 out.error("Use 'tools.get(**self.conan_data[\"sources\"][\"XXXXX\"])' "
                           "in the source() method to get the sources.")
+
+    @run_test("KB-H026", output)
+    def test(out):
+        # INFO: _HooksOutputErrorCollector->ScopedOutput->StringIO to str
+        out_stream = str(output._output._stream.getvalue())
+        if "Linter warnings" in out_stream:
+            out.error("This recipe is not clear according Conan Linter")
 
 
 @raise_if_error_output

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -77,6 +77,9 @@ class _HooksOutputErrorCollector(object):
         url_str = '({})'.format(self.kb_url) if self.kb_id else ""
         self._output.error(self._get_message(message) + " " + url_str)
 
+    def __str__(self):
+        return self._output._stream.getvalue()
+
     @property
     def failed(self):
         return self._error
@@ -302,10 +305,9 @@ def pre_source(output, conanfile, conanfile_path, **kwargs):
 
     @run_test("KB-H026", output)
     def test(out):
-        # INFO: _HooksOutputErrorCollector->ScopedOutput->StringIO to str
-        out_stream = str(output._output._stream.getvalue())
-        if "Linter warnings" in out_stream:
-            out.error("Linter warnings detected. Check the warnings in the output and fix them in the recipe")
+        if "Linter warnings" in str(output):
+            out.error("Linter warnings detected. Check the warnings in the output and fix them " \
+                      "in the recipe")
 
 
 @raise_if_error_output

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -305,7 +305,7 @@ def pre_source(output, conanfile, conanfile_path, **kwargs):
         # INFO: _HooksOutputErrorCollector->ScopedOutput->StringIO to str
         out_stream = str(output._output._stream.getvalue())
         if "Linter warnings" in out_stream:
-            out.error("This recipe is not clear according Conan Linter")
+            out.error("Linter warnings detected. Check the warnings in the output and fix them in the recipe")
 
 
 @raise_if_error_output

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -414,5 +414,7 @@ class ConanCenterTests(ConanClientTestCase):
         """)
         tools.save('conanfile.py', content=conanfile)
         output = self.conan(['create', '.', 'name/version@jgsogo/test'])
-        self.assertIn("ERROR: [LINTER WARNINGS (KB-H026)] This recipe is not clear according " \
-                      "Conan Linter", output)
+        self.assertIn("ERROR: [LINTER WARNINGS (KB-H026)] Linter warnings detected." \
+                      " Check the warnings in the output and fix them in the recipe", output)
+        self.assertIn("Linter warnings", output)
+        self.assertIn("WARN: Linter. Line 1: Unused tools imported from conans", output)

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -87,6 +87,7 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [TEST PACKAGE FOLDER (KB-H024)] There is no 'test_package' for this "
                       "recipe", output)
         self.assertIn("[META LINES (KB-H025)] OK", output)
+        self.assertIn("[LINTER WARNINGS (KB-H026)] OK", output)
         self.assertIn("ERROR: [CONAN CENTER INDEX URL (KB-H027)] The attribute 'url' should " \
                       "point to: https://github.com/conan-io/conan-center-index", output)
         self.assertIn("[CMAKE MINIMUM VERSION (KB-H028)] OK", output)
@@ -110,6 +111,7 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [TEST PACKAGE FOLDER (KB-H024)] There is no 'test_package' for this "
                       "recipe", output)
         self.assertIn("[META LINES (KB-H025)] OK", output)
+        self.assertIn("[LINTER WARNINGS (KB-H026)] OK", output)
         self.assertIn("[CMAKE MINIMUM VERSION (KB-H028)] OK", output)
 
     def test_conanfile_header_only_with_settings(self):
@@ -130,6 +132,7 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [TEST PACKAGE FOLDER (KB-H024)] There is no 'test_package' for this "
                       "recipe", output)
         self.assertIn("[META LINES (KB-H025)] OK", output)
+        self.assertIn("[LINTER WARNINGS (KB-H026)] OK", output)
         self.assertIn("[CMAKE MINIMUM VERSION (KB-H028)] OK", output)
 
     def test_conanfile_installer(self):
@@ -388,7 +391,7 @@ class ConanCenterTests(ConanClientTestCase):
         output = self.conan(['create', '.', 'name/version@jgsogo/test'])
         self.assertIn("[CONAN CENTER INDEX URL (KB-H027)] OK", output)
 
-    def test_cmake_minimum_verstion(self):
+    def test_cmake_minimum_version(self):
         conanfile = self.conanfile_base.format(placeholder="exports_sources = \"CMakeLists.txt\"")
         cmake = """project(test)
         """
@@ -399,3 +402,17 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [CMAKE MINIMUM VERSION (KB-H028)] The CMake file '%s' must contain a "
                       "minimum version declared (e.g. cmake_minimum_required(VERSION 3.1.2))" % path,
                       output)
+
+    def test_linter_warnings(self):
+        conanfile = textwrap.dedent("""\
+        from conans import ConanFile, tools, CMake
+        import os
+        import platform
+
+        class AConan(ConanFile):
+            pass
+        """)
+        tools.save('conanfile.py', content=conanfile)
+        output = self.conan(['create', '.', 'name/version@jgsogo/test'])
+        self.assertIn("ERROR: [LINTER WARNINGS (KB-H026)] This recipe is not clear according " \
+                      "Conan Linter", output)


### PR DESCRIPTION
If the message _Linter warnings_ is present in the output stream, so this hook will raise an error.

We could empathize the linter messages, but it will consumes some new lines in middle of the output and it will be duplicated.

closes #107

Wiki:

#### **<a name="KB-H026">#KB-H026</a>: "LINTER WARNINGS"**

Conan is equipped with [Python linter](https://docs.conan.io/en/latest/integrations/linting/recipe.html) which can find prone errors in your recipe.
All warnings reported by the linter must be fixed to accept your recipe in CCI.

