### PR TITLE
#100 do not allow system requirements

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -270,8 +270,13 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
 
     @run_test("KB-H031", output)
     def test(out):
-        if "def system_requirements" in conanfile_content:
-            out.error("The method 'system_requirements' is not allowed in the recipe.")
+        if "def system_requirements" in conanfile_content and \
+           "SystemPackageTool" in conanfile_content:
+            import re
+            match = re.search(r'(\S+)\s?=\s?SystemPackageTool', conanfile_content)
+            if ("SystemPackageTool().install" in conanfile_content) or \
+               (match and "{}.install".format(match.group(1)) in conanfile_content):
+                out.error("The method 'SystemPackageTool.install' is not allowed in the recipe.")
 
 
 @raise_if_error_output

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -32,7 +32,8 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H025": "META LINES",
              "KB-H027": "CONAN CENTER INDEX URL",
              "KB-H028": "CMAKE MINIMUM VERSION",
-             "KB-H029": "TEST PACKAGE - RUN ENVIRONMENT"}
+             "KB-H029": "TEST PACKAGE - RUN ENVIRONMENT",
+             "KB-H031": "SYSTEM REQUIREMENTS"}
 
 
 class _HooksOutputErrorCollector(object):
@@ -266,6 +267,11 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
         if "RunEnvironment" in test_package_conanfile:
             out.error("The 'RunEnvironment()' build helper is no longer needed. "
                       "It has been integrated into the self.run(..., run_environment=True)")
+
+    @run_test("KB-H031", output)
+    def test(out):
+        if "def system_requirements" in conanfile_content:
+            out.error("The method 'system_requirements' is not allowed in the recipe.")
 
 
 @raise_if_error_output

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -284,6 +284,9 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
 
     @run_test("KB-H032", output)
     def test(out):
+        if conanfile.name in ["libusb"]:
+            out.info("'{}' is part of the allowlist.".format(conanfile.name))
+            return
         if "def system_requirements" in conanfile_content and \
            "SystemPackageTool" in conanfile_content:
             import re

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -38,7 +38,8 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H029": "TEST PACKAGE - RUN ENVIRONMENT",
              "KB-H030": "CONANDATA.YML FORMAT",
              "KB-H031": "CONANDATA.YML REDUCE",
-             "KB-H032": "SYSTEM REQUIREMENTS"}
+             "KB-H032": "SYSTEM REQUIREMENTS",
+            }
 
 
 class _HooksOutputErrorCollector(object):

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -416,4 +416,16 @@ class ConanCenterTests(ConanClientTestCase):
         """)
         tools.save('conanfile.py', content=conanfile)
         output = self.conan(['create', '.', 'name/version@user/test'])
-        self.assertIn("ERROR: [SYSTEM REQUIREMENTS (KB-H031)] The method 'system_requirements' is not allowed in the recipe.", output)
+        self.assertIn("[SYSTEM REQUIREMENTS (KB-H031)] OK", output)
+
+        conanfile += "        installer.install([])"
+        tools.save('conanfile.py', content=conanfile)
+        output = self.conan(['create', '.', 'name/version@user/test'])
+        self.assertIn("ERROR: [SYSTEM REQUIREMENTS (KB-H031)] The method " \
+                      "'SystemPackageTool.install' is not allowed in the recipe.", output)
+
+        conanfile = conanfile.replace("installer.install([])", "SystemPackageTool().install([])")
+        tools.save('conanfile.py', content=conanfile)
+        output = self.conan(['create', '.', 'name/version@user/test'])
+        self.assertIn("ERROR: [SYSTEM REQUIREMENTS (KB-H031)] The method " \
+                      "'SystemPackageTool.install' is not allowed in the recipe.", output)

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -88,7 +88,7 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [CONAN CENTER INDEX URL (KB-H027)] The attribute 'url' should " \
                       "point to: https://github.com/conan-io/conan-center-index", output)
         self.assertIn("[CMAKE MINIMUM VERSION (KB-H028)] OK", output)
-        self.assertIn("[SYSTEM REQUIREMENTS (KB-H031)] OK", output)
+        self.assertIn("[SYSTEM REQUIREMENTS (KB-H032)] OK", output)
 
     def test_conanfile_header_only(self):
         tools.save('conanfile.py', content=self.conanfile_header_only)
@@ -110,7 +110,7 @@ class ConanCenterTests(ConanClientTestCase):
                       "recipe", output)
         self.assertIn("[META LINES (KB-H025)] OK", output)
         self.assertIn("[CMAKE MINIMUM VERSION (KB-H028)] OK", output)
-        self.assertIn("[SYSTEM REQUIREMENTS (KB-H031)] OK", output)
+        self.assertIn("[SYSTEM REQUIREMENTS (KB-H032)] OK", output)
 
     def test_conanfile_header_only_with_settings(self):
         tools.save('conanfile.py', content=self.conanfile_header_only_with_settings)
@@ -131,7 +131,7 @@ class ConanCenterTests(ConanClientTestCase):
                       "recipe", output)
         self.assertIn("[META LINES (KB-H025)] OK", output)
         self.assertIn("[CMAKE MINIMUM VERSION (KB-H028)] OK", output)
-        self.assertIn("[SYSTEM REQUIREMENTS (KB-H031)] OK", output)
+        self.assertIn("[SYSTEM REQUIREMENTS (KB-H032)] OK", output)
 
     def test_conanfile_installer(self):
         tools.save('conanfile.py', content=self.conanfile_installer)
@@ -414,16 +414,16 @@ class ConanCenterTests(ConanClientTestCase):
         """)
         tools.save('conanfile.py', content=conanfile)
         output = self.conan(['create', '.', 'name/version@user/test'])
-        self.assertIn("[SYSTEM REQUIREMENTS (KB-H031)] OK", output)
+        self.assertIn("[SYSTEM REQUIREMENTS (KB-H032)] OK", output)
 
         conanfile += "        installer.install([])"
         tools.save('conanfile.py', content=conanfile)
         output = self.conan(['create', '.', 'name/version@user/test'])
-        self.assertIn("ERROR: [SYSTEM REQUIREMENTS (KB-H031)] The method " \
+        self.assertIn("ERROR: [SYSTEM REQUIREMENTS (KB-H032)] The method " \
                       "'SystemPackageTool.install' is not allowed in the recipe.", output)
 
         conanfile = conanfile.replace("installer.install([])", "SystemPackageTool().install([])")
         tools.save('conanfile.py', content=conanfile)
         output = self.conan(['create', '.', 'name/version@user/test'])
-        self.assertIn("ERROR: [SYSTEM REQUIREMENTS (KB-H031)] The method " \
+        self.assertIn("ERROR: [SYSTEM REQUIREMENTS (KB-H032)] The method " \
                       "'SystemPackageTool.install' is not allowed in the recipe.", output)

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -472,6 +472,10 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [SYSTEM REQUIREMENTS (KB-H032)] The method " \
                       "'SystemPackageTool.install' is not allowed in the recipe.", output)
 
+        output = self.conan(['create', '.', 'libusb/version@user/test'])
+        self.assertIn("[SYSTEM REQUIREMENTS (KB-H032)] 'libusb' is part of the allowlist.", output)
+        self.assertNotIn("ERROR: [SYSTEM REQUIREMENTS (KB-H032)]", output)
+
     def test_imports_not_allowed(self):
         conanfile_tp = textwrap.dedent("""\
         from conans import ConanFile, tools

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -442,6 +442,7 @@ class ConanCenterTests(ConanClientTestCase):
         tools.save('CMakeLists.txt', content=cmake)
         output = self.conan(['create', '.', 'name/version@user/test'])
         self.assertIn("[CMAKE MINIMUM VERSION (KB-H028)] OK", output)
+        self.assertNotIn("ERROR [CMAKE MINIMUM VERSION (KB-H028)]", output)
 
     def test_system_requirements(self):
         conanfile = textwrap.dedent("""\
@@ -469,7 +470,6 @@ class ConanCenterTests(ConanClientTestCase):
         output = self.conan(['create', '.', 'name/version@user/test'])
         self.assertIn("ERROR: [SYSTEM REQUIREMENTS (KB-H032)] The method " \
                       "'SystemPackageTool.install' is not allowed in the recipe.", output)
-        self.assertNotIn("ERROR [CMAKE MINIMUM VERSION (KB-H028)]", output)
 
     def test_no_author(self):
         conanfile = textwrap.dedent("""\

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -90,6 +90,7 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [CONAN CENTER INDEX URL (KB-H027)] The attribute 'url' should " \
                       "point to: https://github.com/conan-io/conan-center-index", output)
         self.assertIn("[CMAKE MINIMUM VERSION (KB-H028)] OK", output)
+        self.assertIn("[SYSTEM REQUIREMENTS (KB-H031)] OK", output)
 
     def test_conanfile_header_only(self):
         tools.save('conanfile.py', content=self.conanfile_header_only)
@@ -111,6 +112,7 @@ class ConanCenterTests(ConanClientTestCase):
                       "recipe", output)
         self.assertIn("[META LINES (KB-H025)] OK", output)
         self.assertIn("[CMAKE MINIMUM VERSION (KB-H028)] OK", output)
+        self.assertIn("[SYSTEM REQUIREMENTS (KB-H031)] OK", output)
 
     def test_conanfile_header_only_with_settings(self):
         tools.save('conanfile.py', content=self.conanfile_header_only_with_settings)
@@ -131,6 +133,7 @@ class ConanCenterTests(ConanClientTestCase):
                       "recipe", output)
         self.assertIn("[META LINES (KB-H025)] OK", output)
         self.assertIn("[CMAKE MINIMUM VERSION (KB-H028)] OK", output)
+        self.assertIn("[SYSTEM REQUIREMENTS (KB-H031)] OK", output)
 
     def test_conanfile_installer(self):
         tools.save('conanfile.py', content=self.conanfile_installer)
@@ -399,3 +402,18 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [CMAKE MINIMUM VERSION (KB-H028)] The CMake file '%s' must contain a "
                       "minimum version declared (e.g. cmake_minimum_required(VERSION 3.1.2))" % path,
                       output)
+
+    def test_system_requirements(self):
+        conanfile = textwrap.dedent("""\
+        from conans import ConanFile
+        from conans.tools import SystemPackageTool
+        class SystemReqConan(ConanFile):
+            url = "https://github.com/conan-io/conan-center-index"
+            license = "fake_license"
+            description = "whatever"
+            def system_requirements(self):
+                installer = SystemPackageTool()
+        """)
+        tools.save('conanfile.py', content=conanfile)
+        output = self.conan(['create', '.', 'name/version@user/test'])
+        self.assertIn("ERROR: [SYSTEM REQUIREMENTS (KB-H031)] The method 'system_requirements' is not allowed in the recipe.", output)


### PR DESCRIPTION
As discussed before, `system_requirements` is evil and should be avoided. This hook looks its declaration in the conanfile.

closes #100 

Wiki:

#### **<a name="KB-H032">#KB-H032</a>: "SYSTEM REQUIREMENTS"**

System requires can be used as an option when a Conan package is not available the same package can be installer system package manager. However, it can cause  reproducibility problems, since the package may vary according the distribution or OS. Conan is not able to track its metadata, so that, installing system packages by recipe is not allowed.