### PR TITLE
Exclude CCCL from KB-H014

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -377,7 +377,8 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
 
     @run_test("KB-H014", output)
     def test(out):
-        if conanfile.name in ["ms-gsl"]:
+        # INFO: Whitelist for package names
+        if conanfile.name in ["ms-gsl", "cccl"]:
             return
         if not _files_match_settings(conanfile, conanfile.package_folder, out):
             out.error("Packaged artifacts does not match the settings used: os=%s, compiler=%s"


### PR DESCRIPTION
Related PR: https://github.com/conan-io/conan-center-index/pull/156

CCCL package only exports a bash script to bin/ folder, however, the conan-center hook expects .exe.