### PR TITLE
Exclude test_package/build from KB028

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -37,7 +37,8 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H028": "CMAKE MINIMUM VERSION",
              "KB-H029": "TEST PACKAGE - RUN ENVIRONMENT",
              "KB-H030": "CONANDATA.YML FORMAT",
-             "KB-H031": "CONANDATA.YML REDUCE"}
+             "KB-H031": "CONANDATA.YML REDUCE",
+            }
 
 
 class _HooksOutputErrorCollector(object):

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -249,7 +249,8 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
             for (root, _, filenames) in os.walk(folder):
                 for filename in filenames:
                     if filename.lower().startswith("cmake") and \
-                    (filename.endswith(".txt") or filename.endswith(".cmake")):
+                       (filename.endswith(".txt") or filename.endswith(".cmake")) and \
+                       os.path.join("test_package", "build") not in root:
                         cmake_path = os.path.join(root, filename)
                         cmake_content = tools.load(cmake_path).lower()
                         if not "cmake_minimum_required(version" in cmake_content:

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -424,6 +424,7 @@ class ConanCenterTests(ConanClientTestCase):
         # validate residual cmake files in test_package/build
         output = self.conan(['create', '.', 'name/version@user/test'])
         self.assertIn("[CMAKE MINIMUM VERSION (KB-H028)] OK", output)
+        self.assertNotIn("ERROR [CMAKE MINIMUM VERSION (KB-H028)]", output)
 
         cmake = textwrap.dedent("""CMAKE_MINIMUM_REQUIRED (VERSION 2.8.11)
         project(test)
@@ -438,3 +439,4 @@ class ConanCenterTests(ConanClientTestCase):
         tools.save('CMakeLists.txt', content=cmake)
         output = self.conan(['create', '.', 'name/version@user/test'])
         self.assertIn("[CMAKE MINIMUM VERSION (KB-H028)] OK", output)
+        self.assertNotIn("ERROR [CMAKE MINIMUM VERSION (KB-H028)]", output)

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -397,3 +397,30 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [CMAKE MINIMUM VERSION (KB-H028)] The CMake file '%s' must contain a "
                       "minimum version declared (e.g. cmake_minimum_required(VERSION 3.1.2))" % path,
                       output)
+
+    def test_cmake_minimum_version_test_package(self):
+        conanfile = self.conanfile_base.format(placeholder="exports_sources = \"CMakeLists.txt\"")
+        conanfile_tp = textwrap.dedent("""\
+        from conans import ConanFile, tools, CMake
+
+        class TestConan(ConanFile):
+            settings = "os", "arch"
+
+            def build(self):
+                cmake = CMake(self)
+
+            def test(self):
+                self.run("echo bar", run_environment=True)
+        """)
+        cmake = """cmake_minimum_required(VERSION 2.8.11)
+        project(test)
+        """
+        tools.save('conanfile.py', content=conanfile)
+        tools.save('CMakeLists.txt', content=cmake)
+        tools.save('test_package/CMakeLists.txt', content=cmake)
+        tools.save('test_package/conanfile.py', content=conanfile_tp)
+        output = self.conan(['create', '.', 'name/version@user/test'])
+        self.assertIn("[CMAKE MINIMUM VERSION (KB-H028)] OK", output)
+        # validate residual cmake files in test_package/build
+        output = self.conan(['create', '.', 'name/version@user/test'])
+        self.assertIn("[CMAKE MINIMUM VERSION (KB-H028)] OK", output)


### PR DESCRIPTION
When a package is built for its first time, the cmake files generated on test_package/build folder will remain for the next build. However, the hook KB-H028 is scanning that folder which should not validate as part of recipe context.

fixes #117 