### PR TITLE
#101 Dont allow imports method for test_package

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -38,8 +38,8 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H029": "TEST PACKAGE - RUN ENVIRONMENT",
              "KB-H030": "CONANDATA.YML FORMAT",
              "KB-H031": "CONANDATA.YML REDUCE",
-             "KB-H034": "TEST PACKAGE - IMPORTS",
-             }
+             "KB-H034": "NO IMPORTS()",
+            }
 
 
 class _HooksOutputErrorCollector(object):

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -39,7 +39,7 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H029": "TEST PACKAGE - RUN ENVIRONMENT",
              "KB-H030": "CONANDATA.YML FORMAT",
              "KB-H031": "CONANDATA.YML REDUCE",
-             "KB-H034": "NO IMPORTS()",
+             "KB-H034": "TEST PACKAGE - NO IMPORTS()",
              "KB-H037": "NO AUTHOR",
             }
 

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -37,7 +37,9 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H028": "CMAKE MINIMUM VERSION",
              "KB-H029": "TEST PACKAGE - RUN ENVIRONMENT",
              "KB-H030": "CONANDATA.YML FORMAT",
-             "KB-H031": "CONANDATA.YML REDUCE"}
+             "KB-H031": "CONANDATA.YML REDUCE",
+             "KB-H034": "TEST PACKAGE - IMPORTS",
+             }
 
 
 class _HooksOutputErrorCollector(object):
@@ -317,6 +319,16 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
                             out.error("Additional entry %s not allowed in 'sources':'%s' of "
                                       "conandata.yml" % (entries, version))
                             return
+
+    @run_test("KB-H034", output)
+    def test(out):
+        test_package_path = os.path.join(export_folder_path, "test_package")
+        if not os.path.exists(os.path.join(test_package_path, "conanfile.py")):
+            return
+
+        test_package_conanfile = tools.load(os.path.join(test_package_path, "conanfile.py"))
+        if "def imports" in test_package_conanfile:
+            out.error("The method `imports` is not allowed in test_package/conanfile.py")
 
 
 @raise_if_error_output

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -440,6 +440,7 @@ class ConanCenterTests(ConanClientTestCase):
         tools.save('CMakeLists.txt', content=cmake)
         output = self.conan(['create', '.', 'name/version@user/test'])
         self.assertIn("[CMAKE MINIMUM VERSION (KB-H028)] OK", output)
+        self.assertNotIn("ERROR [CMAKE MINIMUM VERSION (KB-H028)]", output)
 
     def test_imports_not_allowed(self):
         conanfile_tp = textwrap.dedent("""\
@@ -462,8 +463,7 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("[TEST PACKAGE FOLDER (KB-H024)] OK", output)
         self.assertIn("[TEST PACKAGE - RUN ENVIRONMENT (KB-H029)] OK", output)
         self.assertIn("ERROR: [NO IMPORTS() (KB-H034)] The method `imports` is not " \
-                      "allowed in test_package/conanfile.py", output)
-        self.assertNotIn("ERROR [CMAKE MINIMUM VERSION (KB-H028)]", output)
+                      "allowed in test_package/conanfile.py", output)        
 
     def test_no_author(self):
         conanfile = textwrap.dedent("""\

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -218,7 +218,7 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("[TEST PACKAGE FOLDER (KB-H024)] OK", output)
         self.assertIn("[TEST PACKAGE - RUN ENVIRONMENT (KB-H029)] OK", output)
         self.assertIn("[EXPORT LICENSE (KB-H023)] OK", output)
-        self.assertIn("[NO IMPORTS() (KB-H034)] OK", output)
+        self.assertIn("[TEST PACKAGE - NO IMPORTS() (KB-H034)] OK", output)
 
     def test_exports_licenses(self):
         tools.save('conanfile.py',

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -465,7 +465,7 @@ class ConanCenterTests(ConanClientTestCase):
         output = self.conan(['create', '.', 'name/version@user/test'])
         self.assertIn("[TEST PACKAGE FOLDER (KB-H024)] OK", output)
         self.assertIn("[TEST PACKAGE - RUN ENVIRONMENT (KB-H029)] OK", output)
-        self.assertIn("ERROR: [NO IMPORTS() (KB-H034)] The method `imports` is not " \
+        self.assertIn("ERROR: [TEST PACKAGE - NO IMPORTS() (KB-H034)] The method `imports` is not " \
                       "allowed in test_package/conanfile.py", output)        
 
     def test_linter_warnings(self):

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -215,7 +215,7 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("[TEST PACKAGE FOLDER (KB-H024)] OK", output)
         self.assertIn("[TEST PACKAGE - RUN ENVIRONMENT (KB-H029)] OK", output)
         self.assertIn("[EXPORT LICENSE (KB-H023)] OK", output)
-        self.assertIn("[TEST PACKAGE - IMPORTS (KB-H034)] OK", output)
+        self.assertIn("[NO IMPORTS() (KB-H034)] OK", output)
 
     def test_exports_licenses(self):
         tools.save('conanfile.py',
@@ -419,5 +419,5 @@ class ConanCenterTests(ConanClientTestCase):
         output = self.conan(['create', '.', 'name/version@user/test'])
         self.assertIn("[TEST PACKAGE FOLDER (KB-H024)] OK", output)
         self.assertIn("[TEST PACKAGE - RUN ENVIRONMENT (KB-H029)] OK", output)
-        self.assertIn("ERROR: [TEST PACKAGE - IMPORTS (KB-H034)] The method `imports` is not " \
+        self.assertIn("ERROR: [NO IMPORTS() (KB-H034)] The method `imports` is not " \
                       "allowed in test_package/conanfile.py", output)


### PR DESCRIPTION
closes #101

Wiki:


#### **<a name="KB-H034">#KB-H034</a>: "TEST PACKAGE - IMPORTS"**

The method [imports](https://docs.conan.io/en/latest/reference/conanfile/methods.html#imports) helps the test package stage copying all dynamic libraries and special resources. However, the [run_environment](https://docs.conan.io/en/latest/reference/conanfile/other.html#running-commands) parameter, used when running commands, is able to solve all paths to the dynamic libraries installed in your cache.