### PR TITLE
Fix cmake hook - accepts whitespace

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -252,7 +252,8 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
                     (filename.endswith(".txt") or filename.endswith(".cmake")):
                         cmake_path = os.path.join(root, filename)
                         cmake_content = tools.load(cmake_path).lower()
-                        if not "cmake_minimum_required(version" in cmake_content:
+                        if not "cmake_minimum_required(version" in cmake_content and \
+                           not "cmake_minimum_required (version" in cmake_content:
                             file_path = os.path.join(os.path.relpath(root), filename)
                             out.error("The CMake file '%s' must contain a minimum version " \
                                       "declared (e.g. cmake_minimum_required(VERSION 3.1.2))" %

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -392,8 +392,22 @@ class ConanCenterTests(ConanClientTestCase):
         """
         tools.save('conanfile.py', content=conanfile)
         tools.save('CMakeLists.txt', content=cmake)
-        output = self.conan(['create', '.', 'name/version@jgsogo/test'])
+        output = self.conan(['create', '.', 'name/version@user/test'])
         path = os.path.join(".", "CMakeLists.txt")
         self.assertIn("ERROR: [CMAKE MINIMUM VERSION (KB-H028)] The CMake file '%s' must contain a "
                       "minimum version declared (e.g. cmake_minimum_required(VERSION 3.1.2))" % path,
                       output)
+
+        cmake = textwrap.dedent("""CMAKE_MINIMUM_REQUIRED (VERSION 2.8.11)
+        project(test)
+        """)
+        tools.save('CMakeLists.txt', content=cmake)
+        output = self.conan(['create', '.', 'name/version@user/test'])
+        self.assertIn("[CMAKE MINIMUM VERSION (KB-H028)] OK", output)
+
+        cmake = textwrap.dedent("""cmake_minimum_required(VERSION 2.8.11)
+        project(test)
+        """)
+        tools.save('CMakeLists.txt', content=cmake)
+        output = self.conan(['create', '.', 'name/version@user/test'])
+        self.assertIn("[CMAKE MINIMUM VERSION (KB-H028)] OK", output)


### PR DESCRIPTION
Fix cmake minimum required hook. Both statements are valid:

```
cmake_minimum_required(version 3.15)
cmake_minimum_required (version 3.15)
```

The white space was not detected as valid.