### PR TITLE
Custom methods must be protected

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -325,6 +325,7 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
         def get_methods(conanfile):
             methods = []
             for member in dir(conanfile):
+
                 try:
                     if callable(getattr(conanfile, member)):
                         methods.append(str(member))
@@ -335,10 +336,11 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
         mock = ConanFile(conanfile.output, None)
         valid_attrs = get_methods(mock)
         current_attrs = get_methods(conanfile)
-        invalid_attrs = []
+        invalid_attrs = re.findall(r"def (__.*[^_])\s?\(", conanfile_content, re.MULTILINE)
         for attr in current_attrs:
             if not attr.startswith("_") and attr not in valid_attrs:
                 invalid_attrs.append(attr)
+
         if invalid_attrs:
             out.error("Custom methods must be declared as protected. " \
                       "The follow methods are invalid: '{}'".format("', '".join(invalid_attrs)))

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -88,6 +88,7 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [CONAN CENTER INDEX URL (KB-H027)] The attribute 'url' should " \
                       "point to: https://github.com/conan-io/conan-center-index", output)
         self.assertIn("[CMAKE MINIMUM VERSION (KB-H028)] OK", output)
+        self.assertIn("[CUSTOM METHODS (KB-H036)] OK", output)
 
     def test_conanfile_header_only(self):
         tools.save('conanfile.py', content=self.conanfile_header_only)
@@ -109,6 +110,7 @@ class ConanCenterTests(ConanClientTestCase):
                       "recipe", output)
         self.assertIn("[META LINES (KB-H025)] OK", output)
         self.assertIn("[CMAKE MINIMUM VERSION (KB-H028)] OK", output)
+        self.assertIn("[CUSTOM METHODS (KB-H036)] OK", output)
 
     def test_conanfile_header_only_with_settings(self):
         tools.save('conanfile.py', content=self.conanfile_header_only_with_settings)
@@ -129,6 +131,7 @@ class ConanCenterTests(ConanClientTestCase):
                       "recipe", output)
         self.assertIn("[META LINES (KB-H025)] OK", output)
         self.assertIn("[CMAKE MINIMUM VERSION (KB-H028)] OK", output)
+        self.assertIn("[CUSTOM METHODS (KB-H036)] OK", output)
 
     def test_conanfile_installer(self):
         tools.save('conanfile.py', content=self.conanfile_installer)
@@ -149,6 +152,7 @@ class ConanCenterTests(ConanClientTestCase):
                       "recipe", output)
         self.assertIn("[META LINES (KB-H025)] OK", output)
         self.assertIn("[CMAKE MINIMUM VERSION (KB-H028)] OK", output)
+        self.assertIn("[CUSTOM METHODS (KB-H036)] OK", output)
 
     def test_shebang(self):
         conanfile = textwrap.dedent("""\
@@ -397,3 +401,28 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [CMAKE MINIMUM VERSION (KB-H028)] The CMake file '%s' must contain a "
                       "minimum version declared (e.g. cmake_minimum_required(VERSION 3.1.2))" % path,
                       output)
+
+    def test_invalid_recipe_methods(self):
+        conanfile = textwrap.dedent("""\
+        from conans import ConanFile
+        class AConan(ConanFile):
+            url = "fake_url.com"
+            license = "fake_license"
+            description = "whatever"
+            homepage = "homepage.com"
+            topics = ("fake_topic", "another_fake_topic")
+
+            def configure(self):
+                self.output.info("ok")
+
+            def barbarian(self):
+                self.output.info("Conan")
+
+            def my_own_method(self):
+                self.output.info("foobar")
+        """)
+        tools.save('conanfile.py', content=conanfile)
+        output = self.conan(['create', '.', 'name/version@user/test'])
+        self.assertIn("ERROR: [CUSTOM METHODS (KB-H036)] Custom methods must be declared as " \
+                      "protected. The follow methods are invalid: 'barbarian', " \
+                      "'my_own_method'", output)

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -418,11 +418,21 @@ class ConanCenterTests(ConanClientTestCase):
             def barbarian(self):
                 self.output.info("Conan")
 
-            def my_own_method(self):
+            def __my_own_method(self):
                 self.output.info("foobar")
+
+            def __my_private_method(self):
+                self.output.info("foobar")
+
+            def __abs__(self):
+                return self.version
+
+            def _baz(self):
+                self.output.info("qux")
+
         """)
         tools.save('conanfile.py', content=conanfile)
         output = self.conan(['create', '.', 'name/version@user/test'])
-        self.assertIn("ERROR: [CUSTOM METHODS (KB-H036)] Custom methods must be declared as " \
-                      "protected. The follow methods are invalid: 'barbarian', " \
-                      "'my_own_method'", output)
+        self.assertIn("ERROR: [CUSTOM METHODS (KB-H036)] Custom methods must be declared as "
+                      "protected. The follow methods are invalid: '__my_own_method', "
+                      "'__my_private_method', 'barbarian'", output)


### PR DESCRIPTION
- Any method declared as public, must be provided from ConanFile
- Any custom method must be declared as protected
- Any private method is not be accepted

closes #126 

Wiki:

#### **<a name="KB-H036">#KB-H036</a>: "CUSTOM METHODS"**

When a new method have to be added to the [recipe](https://docs.conan.io/en/latest/reference/conanfile.html#conanfile-py), and it is not a default one provided by ConanFile, it must added as protected:

```python
class Recipe(ConanFile):
    def configure(self): # default methods are public
        pass

    def _configure_cmake(self): # custom methods are protected
        pass

    def __private_routine(self): # private should not be used. Use protected 
instead.
	     pass
