### PR TITLE
Conanfile should not contain author declared

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -37,7 +37,9 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H028": "CMAKE MINIMUM VERSION",
              "KB-H029": "TEST PACKAGE - RUN ENVIRONMENT",
              "KB-H030": "CONANDATA.YML FORMAT",
-             "KB-H031": "CONANDATA.YML REDUCE"}
+             "KB-H031": "CONANDATA.YML REDUCE",
+             "KB-H037": "NO AUTHOR",
+            }
 
 
 class _HooksOutputErrorCollector(object):
@@ -318,6 +320,14 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
                             out.error("Additional entry %s not allowed in 'sources':'%s' of "
                                       "conandata.yml" % (entries, version))
                             return
+
+    @run_test("KB-H037", output)
+    def test(out):
+        author = getattr(conanfile, "author", None)
+        if author:
+            if isinstance(author, str):
+                author = '"%s"' % author
+            out.error("Conanfile should not contain author. Remove 'author = {}'".format(author))
 
 
 @raise_if_error_output

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -411,3 +411,25 @@ class ConanCenterTests(ConanClientTestCase):
         tools.save('CMakeLists.txt', content=cmake)
         output = self.conan(['create', '.', 'name/version@user/test'])
         self.assertIn("[CMAKE MINIMUM VERSION (KB-H028)] OK", output)
+
+    def test_no_author(self):
+        conanfile = textwrap.dedent("""\
+        from conans import ConanFile
+        class AConan(ConanFile):
+            {}
+            def configure(self):
+                pass
+        """)
+        tools.save('conanfile.py', content=conanfile.replace("{}", ""))
+        output = self.conan(['create', '.', 'name/version@user/test'])
+        self.assertIn("[NO AUTHOR (KB-H037)] OK", output)
+
+        tools.save('conanfile.py', content=conanfile.replace("{}", "author = 'foobar'"))
+        output = self.conan(['create', '.', 'name/version@user/test'])
+        self.assertIn('ERROR: [NO AUTHOR (KB-H037)] Conanfile should not contain author. '
+                      'Remove \'author = "foobar"\'', output)
+
+        tools.save('conanfile.py', content=conanfile.replace("{}", "author = ('foo', 'bar')"))
+        output = self.conan(['create', '.', 'name/version@user/test'])
+        self.assertIn('ERROR: [NO AUTHOR (KB-H037)] Conanfile should not contain author. '
+                      'Remove \'author = (\'foo\', \'bar\')', output)


### PR DESCRIPTION
closes #97

- I loved @Croydon comment, so I've used it on Wiki description.

Wiki:

#### **<a name="KB-H037">#KB-H037</a>: "NO AUTHOR"**

Since the entire community is maintaining all CCI recipes, putting just one name in a recipe is unfair, putting all names is unmanageable. All authors can be found in the Git logs.