### PR TITLE
Validate non-ascii characters 

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -2,6 +2,7 @@ import fnmatch
 import inspect
 import re
 import os
+import sys
 from collections import defaultdict
 
 import yaml
@@ -334,8 +335,11 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
     @run_test("KB-H038", output)
     def test(out):
         try:
-            open(conanfile_path, encoding='ascii').read()
-        except UnicodeDecodeError as error:
+            if sys.version_info[0] < 3:
+                open(conanfile_path).read()
+            else:
+                open(conanfile_path, encoding='ascii').read()
+        except (SyntaxError, UnicodeDecodeError) as error:
             out.error("This conanfile contains a non-ascii character at position ({}) "
                      "and is not compatible with Python 2".format(error.start))
 

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -39,6 +39,7 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H030": "CONANDATA.YML FORMAT",
              "KB-H031": "CONANDATA.YML REDUCE",
              "KB-H037": "NO AUTHOR",
+             "KB-H038": "ASCII SUPPORT",
             }
 
 
@@ -329,6 +330,14 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
             if isinstance(author, str):
                 author = '"%s"' % author
             out.error("Conanfile should not contain author. Remove 'author = {}'".format(author))
+
+    @run_test("KB-H038", output)
+    def test(out):
+        try:
+            open(conanfile_path, encoding='ascii').read()
+        except UnicodeDecodeError as error:
+            out.warn("This conanfile contains a non-ascii character at position ({}) "
+                     "and is not compatible with Python 2".format(error.start))
 
 
 @raise_if_error_output

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -336,7 +336,7 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
         try:
             open(conanfile_path, encoding='ascii').read()
         except UnicodeDecodeError as error:
-            out.warn("This conanfile contains a non-ascii character at position ({}) "
+            out.error("This conanfile contains a non-ascii character at position ({}) "
                      "and is not compatible with Python 2".format(error.start))
 
 

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -465,15 +465,14 @@ class ConanCenterTests(ConanClientTestCase):
                       'Remove \'author = (\'foo\', \'bar\')', output)
 
     def test_invalid_ascii_recipe(self):
-        conanfile = textwrap.dedent("""\
-        from conans import ConanFile
-        class AConan(ConanFile):
-            description = "open-source file compression that uses the Burrows–Wheeler algorithm."
-
-            def configure(self):
-                pass
-        """)
+        conanfile = textwrap.dedent(b"""
+            from conans import ConanFile
+            class AConan(ConanFile):
+                description = "file compression that uses the Burrows\xe2\x80\x93Wheeler algorithm"
+                def configure(self):
+                    pass
+        """.decode(encoding="utf8"))
         tools.save('conanfile.py', content=conanfile.replace("{}", ""))
         output = self.conan(['create', '.', 'name/version@user/test'])
         self.assertIn("ERROR: [ASCII SUPPORT (KB-H038)] This conanfile contains a non-ascii " \
-                      "character at position (123) and is not compatible with Python 2", output)
+                      "character at position (112) and is not compatible with Python 2", output)

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -1,6 +1,7 @@
 import os
 import platform
 import textwrap
+import sys
 
 from conans import tools
 from conans.client.command import ERROR_INVALID_CONFIGURATION, SUCCESS
@@ -472,7 +473,11 @@ class ConanCenterTests(ConanClientTestCase):
                 def configure(self):
                     pass
         """.decode(encoding="utf8"))
-        tools.save('conanfile.py', content=conanfile.replace("{}", ""))
-        output = self.conan(['create', '.', 'name/version@user/test'])
-        self.assertIn("ERROR: [ASCII SUPPORT (KB-H038)] This conanfile contains a non-ascii " \
-                      "character at position (112) and is not compatible with Python 2", output)
+        tools.save('conanfile.py', content=conanfile)
+        try:
+            output = self.conan(['create', '.', 'name/version@user/test'])
+            self.assertIn("ERROR: [ASCII SUPPORT (KB-H038)] This conanfile contains a non-ascii " \
+                    "character at position (112) and is not compatible with Python 2", output)
+        except Exception as error:
+            self.assertLess(sys.version_info[0], 3)
+            self.assertIn(r"SyntaxError: Non-ASCII character '\xe2' in file", str(error))

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -88,6 +88,7 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [CONAN CENTER INDEX URL (KB-H027)] The attribute 'url' should " \
                       "point to: https://github.com/conan-io/conan-center-index", output)
         self.assertIn("[CMAKE MINIMUM VERSION (KB-H028)] OK", output)
+        self.assertIn("[ASCII SUPPORT (KB-H038)] OK", output)
 
     def test_conanfile_header_only(self):
         tools.save('conanfile.py', content=self.conanfile_header_only)
@@ -462,3 +463,17 @@ class ConanCenterTests(ConanClientTestCase):
         output = self.conan(['create', '.', 'name/version@user/test'])
         self.assertIn('ERROR: [NO AUTHOR (KB-H037)] Conanfile should not contain author. '
                       'Remove \'author = (\'foo\', \'bar\')', output)
+
+    def test_invalid_ascii_recipe(self):
+        conanfile = textwrap.dedent("""\
+        from conans import ConanFile
+        class AConan(ConanFile):
+            description = "open-source file compression that uses the Burrows–Wheeler algorithm."
+
+            def configure(self):
+                pass
+        """)
+        tools.save('conanfile.py', content=conanfile.replace("{}", ""))
+        output = self.conan(['create', '.', 'name/version@user/test'])
+        self.assertIn("WARN: [ASCII SUPPORT (KB-H038)] This conanfile contains a non-ascii " \
+                      "character at position (123) and is not compatible with Python 2", output)

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -475,5 +475,5 @@ class ConanCenterTests(ConanClientTestCase):
         """)
         tools.save('conanfile.py', content=conanfile.replace("{}", ""))
         output = self.conan(['create', '.', 'name/version@user/test'])
-        self.assertIn("WARN: [ASCII SUPPORT (KB-H038)] This conanfile contains a non-ascii " \
+        self.assertIn("ERROR: [ASCII SUPPORT (KB-H038)] This conanfile contains a non-ascii " \
                       "character at position (123) and is not compatible with Python 2", output)


### PR DESCRIPTION
As Python 2 is close to its retirement, so I preferred keep this hook as an error. After 2020 we can change it to warning instead.

Related issue: https://github.com/conan-io/conan-center-index/pull/278#discussion_r343837509

/cc @madebr @SSE4 

closes #130


Wiki:


#### **<a name="KB-H038">#KB-H038</a>: "ASCII SUPPORT"**

Characters non-ascii are not compatible with Python 2, so they should be avoided.