### PR TITLE
Add hook: recipe linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,15 @@
 
 Repository to develop **experimental** [Conan](https://conan.io) hooks for Conan >= 1.8.
 
-**WARNING**: Hooks were originally named "Plugins"
+ * [Conan Center](#conan-center)
+ * [Attribute checker](#attribute-checker)
+ * [Bintray updater](#bintray-updater)
+ * [Binary linter](#binary-linter)
+ * [Github updater](#github-updater)
+ * [Member typo checker](#members-typo-checker)
+ * [SPDX checker](#spdx-checker)
+ * [Recipe linter](#recipe-linter)
+
 
 ## Hook setup
 
@@ -159,6 +167,21 @@ The hook uses [spdx_lookup](https://pypi.org/project/spdx-lookup/) python module
 Use `pip install spdx_lookup` in order to install required dependency.
 
 The hook is automatically called when *export* command is executed.
+
+### [Recipe linter](hooks/recipe_linter.py)
+
+This hook runs [Pylint](https://www.pylint.org/) over the recipes before exporting
+them (it runs in the `pre_export` hook), it can be really useful to check for
+typos, code flaws or company standards.
+
+There several environment variables you can use to configure it:
+ * `CONAN_PYLINTRC`: path to a configuration file to fully customize Pylint behavior.
+ * `CONAN_PYLINT_WERR`: if set, linting errors will trigger a `ConanException`.
+ * `CONAN_PYLINT_RECIPE_PLUGINS`: list of modules (comma separated list) to load. They are used to register additional checker or dynamic fields before running
+ the linter. By default it points to the `conans.pylint_plugin` module distributed
+ together with Conan, this file contains the declaration of some extra fields that are valid in the `ConanFile` class.
+
+This hook requires additional dependencies to work: `pip install pylint astroid`.
 
 ## License
 

--- a/hooks/recipe_linter.py
+++ b/hooks/recipe_linter.py
@@ -27,8 +27,7 @@ CONAN_HOOK_PYLINT_WERR = "CONAN_PYLINT_WERR"
 def pre_export(output, conanfile_path, *args, **kwargs):
     output.info("Lint recipe '{}'".format(conanfile_path))
 
-    lint_args = ['--verbose',
-                 '--exit-zero',
+    lint_args = ['--exit-zero',
                  '--py3k',
                  '--enable=all',
                  '--reports=no',

--- a/hooks/recipe_linter.py
+++ b/hooks/recipe_linter.py
@@ -50,9 +50,7 @@ def pre_export(output, conanfile_path, *args, **kwargs):
     try:
         command = ['pylint'] + lint_args + ['"{}"'.format(conanfile_path).replace('\\', '/')]
         command = " ".join(command)
-        shell = bool(platform.system() != "Windows")
-        p = subprocess.Popen(command, shell=shell, bufsize=10,
-                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        p = subprocess.Popen(command, bufsize=10, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         pylint_stdout, pylint_stderr = p.communicate()
 
         # Remove ANSI escape sequences

--- a/hooks/recipe_linter.py
+++ b/hooks/recipe_linter.py
@@ -55,7 +55,7 @@ def pre_export(output, conanfile_path, *args, **kwargs):
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         pylint_stdout, pylint_stderr = p.communicate()
 
-        # Remove ANSI escape sequences
+        # Remove ANSI escape sequences from Pylint output (fails in Windows)
         ansi_escape = re.compile(r'\x1B\[[0-?]*[ -/]*[@-~]')
         pylint_stdout = ansi_escape.sub('', pylint_stdout.decode('utf-8'))
     except Exception as exc:

--- a/hooks/recipe_linter.py
+++ b/hooks/recipe_linter.py
@@ -3,16 +3,19 @@
 import os
 import sys
 
+from packaging import version
 from six import StringIO
 
 from conans.errors import ConanException
 
 try:
-    from pylint import lint
-    from pylint.reporters.text import TextReporter, ParseableTextReporter
-    from pylint.reporters.json import JSONReporter
     import astroid  # Conan 'pylint_plugin.py' uses astroid
-except ImportError:
+    from pylint import lint, __version__ as pylint_version
+    if version.parse(pylint_version) >= version.Version("2.4"):
+        from pylint.reporters import JSONReporter
+    else:
+        from pylint.reporters.json import JSONReporter
+except ImportError as e:
     sys.stderr.write("Install pylint to use 'recipe_linter' hook: 'pip install pylint astroid'")
     sys.exit(1)
 

--- a/hooks/recipe_linter.py
+++ b/hooks/recipe_linter.py
@@ -36,7 +36,7 @@ def pre_export(output, conanfile_path, *args, **kwargs):
                  # These were disabled in linter that was inside Conan
                  # '--disable=W0702',  # No exception type(s) specified (bare-except)
                  # '--disable=W0703',  # Catching too general exception Exception (broad-except)
-                 '--init-hook="import sys;sys.path.extend([\'{}\',])"'.format(conanfile_dirname.replace('\\', '\\\\'))
+                 '--init-hook="import sys;sys.path.extend([\'{}\',])"'.format(conanfile_dirname.replace('\\', '/'))
                  ]
 
     pylint_plugins = os.getenv(CONAN_HOOK_PYLINT_RECIPE_PLUGINS, 'conans.pylint_plugin')
@@ -45,15 +45,16 @@ def pre_export(output, conanfile_path, *args, **kwargs):
 
     rc_file = os.getenv(CONAN_HOOK_PYLINT_RCFILE)
     if rc_file:
-        lint_args += ['--rcfile', rc_file]
+        lint_args += ['--rcfile', rc_file.replace('\\', '/')]
 
     try:
-        command = ['pylint'] + lint_args + ['"{}"'.format(conanfile_path).replace('\\', '\\\\')]
+        command = ['pylint'] + lint_args + ['"{}"'.format(conanfile_path).replace('\\', '/')]
         command = " ".join(command)
         shell = bool(platform.system() != "Windows")
         p = subprocess.Popen(command, shell=shell, bufsize=10,
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         pylint_stdout, pylint_stderr = p.communicate()
+
         # Remove ANSI escape sequences
         ansi_escape = re.compile(r'\x1B\[[0-?]*[ -/]*[@-~]')
         pylint_stdout = ansi_escape.sub('', pylint_stdout.decode('utf-8'))

--- a/hooks/recipe_linter.py
+++ b/hooks/recipe_linter.py
@@ -1,20 +1,14 @@
 # coding=utf-8
 
+import json
 import os
 import sys
-
-from packaging import version
-from six import StringIO
 
 from conans.errors import ConanException
 
 try:
     import astroid  # Conan 'pylint_plugin.py' uses astroid
-    from pylint import lint, __version__ as pylint_version
-    if version.parse(pylint_version) >= version.Version("2.4"):
-        from pylint.reporters import JSONReporter
-    else:
-        from pylint.reporters.json import JSONReporter
+    from pylint import epylint as lint
 except ImportError as e:
     sys.stderr.write("Install pylint to use 'recipe_linter' hook: 'pip install pylint astroid'")
     sys.exit(1)
@@ -22,45 +16,46 @@ except ImportError as e:
 
 CONAN_HOOK_PYLINT_RCFILE = "CONAN_PYLINTRC"
 CONAN_HOOK_PYLINT_WERR = "CONAN_PYLINT_WERR"
+CONAN_HOOK_PYLINT_RECIPE_PLUGINS = "CONAN_PYLINT_RECIPE_PLUGINS"
 
 
 def pre_export(output, conanfile_path, *args, **kwargs):
     output.info("Lint recipe '{}'".format(conanfile_path))
 
-    lint_args = ['--exit-zero',
+    lint_args = ['"{}"'.format(conanfile_path),
+                 '--output-format=json',
+                 '--exit-zero',
                  '--py3k',
                  '--enable=all',
                  '--reports=no',
                  '--disable=no-absolute-import',
                  '--persistent=no',
-                 '--load-plugins=conans.pylint_plugin',
                  '--disable=W0702',  # No exception type(s) specified (bare-except)
                  '--disable=W0703',  # Catching too general exception Exception (broad-except)
                  ]
 
-    rc_file = os.getenv(CONAN_HOOK_PYLINT_RCFILE, None)
-    if rc_file:
-        lint_args += ['--rcfile', rc_file]
+    pylint_plugins = os.getenv(CONAN_HOOK_PYLINT_RECIPE_PLUGINS, 'conans.pylint_plugin')
+    if pylint_plugins:
+        lint_args += ['--load-plugins={}'.format(pylint_plugins)]
 
-    lint_args += [conanfile_path]
+    rc_file = os.getenv(CONAN_HOOK_PYLINT_RCFILE)
+    if rc_file:
+        lint_args += ['--rcfile="{}"'.format(rc_file)]
 
     sys.path.insert(0, os.path.dirname(conanfile_path))
     try:
-        buff = StringIO()
-        reporter = JSONReporter(output=buff)
-        if version.parse(pylint_version) >= version.Version("2.0"):
-            lint.Run(lint_args, reporter=reporter, do_exit=False)
-        else:
-            lint.Run(lint_args, reporter=reporter, exit=False)
-    except Exception as e:
-        output.error("Unexpected error running linter: {}".format(e))
+        command_line = " ".join(lint_args)
+        (pylint_stdout, pylint_stderr) = lint.py_run(command_line, return_std=True)
+        messages = json.loads(pylint_stdout.getvalue())
+    except Exception as exc:
+        output.error("Unexpected error running linter: {}".format(exc))
     else:
-        for msg in reporter.messages:
+        for msg in messages:
             line = "{path}:{line}:{column}: {message-id}: {message} ({symbol})".format(**msg)
             output.info(line)
 
         if os.getenv(CONAN_HOOK_PYLINT_WERR) \
-                and any(msg["type"] in ("error", "warning") for msg in reporter.messages):
+                and any(msg["type"] in ("error", "warning") for msg in messages):
             raise ConanException("Package recipe has linter errors. Please fix them.")
     finally:
         sys.path.pop()

--- a/hooks/recipe_linter.py
+++ b/hooks/recipe_linter.py
@@ -1,0 +1,61 @@
+# coding=utf-8
+
+import os
+import sys
+
+from six import StringIO
+
+from conans.errors import ConanException
+
+try:
+    from pylint import lint
+    from pylint.reporters.text import TextReporter, ParseableTextReporter
+    from pylint.reporters.json import JSONReporter
+    import astroid  # Conan 'pylint_plugin.py' uses astroid
+except ImportError:
+    sys.stderr.write("Install pylint to use 'recipe_linter' hook: 'pip install pylint astroid'")
+    sys.exit(1)
+
+
+CONAN_HOOK_PYLINT_RCFILE = "CONAN_PYLINTRC"
+CONAN_HOOK_PYLINT_WERR = "CONAN_PYLINT_WERR"
+
+
+def pre_export(output, conanfile_path, *args, **kwargs):
+    output.info("Lint recipe '{}'".format(conanfile_path))
+
+    lint_args = ['--verbose',
+                 '--exit-zero',
+                 '--py3k',
+                 '--enable=all',
+                 '--reports=no',
+                 '--disable=no-absolute-import',
+                 '--persistent=no',
+                 '--load-plugins=conans.pylint_plugin',
+                 '--disable=W0702',  # No exception type(s) specified (bare-except)
+                 '--disable=W0703',  # Catching too general exception Exception (broad-except)
+                 ]
+
+    rc_file = os.getenv(CONAN_HOOK_PYLINT_RCFILE, None)
+    if rc_file:
+        lint_args += ['--rcfile', rc_file]
+
+    lint_args += [conanfile_path]
+
+    sys.path.insert(0, os.path.dirname(conanfile_path))
+    try:
+        buff = StringIO()
+        reporter = JSONReporter(output=buff)
+        lint.Run(lint_args, reporter=reporter, do_exit=False)
+    except Exception as e:
+        output.error("Unexpected error running linter: {}".format(e))
+    else:
+        for msg in reporter.messages:
+            line = "{path}:{line}:{column}: {message-id}: {message} ({symbol})".format(**msg)
+            output.info(line)
+
+        if os.getenv(CONAN_HOOK_PYLINT_WERR) \
+                and any(msg["type"] in ("error", "warning") for msg in reporter.messages):
+            raise ConanException("Package recipe has linter errors. Please fix them.")
+    finally:
+        sys.path.pop()

--- a/hooks/recipe_linter.py
+++ b/hooks/recipe_linter.py
@@ -50,7 +50,9 @@ def pre_export(output, conanfile_path, *args, **kwargs):
     try:
         command = ['pylint'] + lint_args + ['"{}"'.format(conanfile_path).replace('\\', '/')]
         command = " ".join(command)
-        p = subprocess.Popen(command, bufsize=10, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        shell = bool(platform.system() != "Windows")
+        p = subprocess.Popen(command, shell=shell, bufsize=10,
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         pylint_stdout, pylint_stderr = p.communicate()
 
         # Remove ANSI escape sequences

--- a/hooks/recipe_linter.py
+++ b/hooks/recipe_linter.py
@@ -49,7 +49,10 @@ def pre_export(output, conanfile_path, *args, **kwargs):
     try:
         buff = StringIO()
         reporter = JSONReporter(output=buff)
-        lint.Run(lint_args, reporter=reporter, do_exit=False)
+        if version.parse(pylint_version) >= version.Version("2.0"):
+            lint.Run(lint_args, reporter=reporter, do_exit=False)
+        else:
+            lint.Run(lint_args, reporter=reporter, exit=False)
     except Exception as e:
         output.error("Unexpected error running linter: {}".format(e))
     else:

--- a/tests/requirements_test.txt
+++ b/tests/requirements_test.txt
@@ -2,3 +2,5 @@ pytest>=3.6
 parameterized
 responses
 pluggy==0.11.0
+pylint
+astroid

--- a/tests/test_hooks/test_recipe_linter.py
+++ b/tests/test_hooks/test_recipe_linter.py
@@ -63,13 +63,18 @@ class RecipeLinterTests(ConanClientTestCase):
             self.assertIn("pre_export(): conanfile.py:10:15:"
                           " W0612: Unused variable 'v' (unused-variable)", output)
 
+    def test_path_with_spaces(self):
+        tools.save(os.path.join("path spaces", "conanfile.py"), content=self.conanfile)
+        output = self.conan(['export', 'path spaces/conanfile.py', 'name/version@'])
+        recipe_path = os.path.join(os.getcwd(), "path spaces", "conanfile.py")
+        self.assertIn("pre_export(): Lint recipe '{}'".format(recipe_path), output)
+
     def test_custom_rcfile(self):
         tools.save('conanfile.py', content=self.conanfile)
         tools.save('pylintrc', content="[FORMAT]\nindent-string='  '")
 
         with environment_append({"CONAN_PYLINTRC": os.path.join(os.getcwd(), "pylintrc")}):
             output = self.conan(['export', '.', 'name/version@'])
-
         self.assertIn("pre_export(): conanfile.py:5:0: "
                       "W0311: Bad indentation. Found 4 spaces, expected 2 (bad-indentation)", output)
 

--- a/tests/test_hooks/test_recipe_linter.py
+++ b/tests/test_hooks/test_recipe_linter.py
@@ -1,0 +1,153 @@
+# coding=utf-8
+
+import os
+import textwrap
+
+import six
+from parameterized import parameterized
+
+from conans import tools
+from conans.client.command import ERROR_GENERAL, SUCCESS
+from conans.tools import environment_append
+from hooks.recipe_linter import CONAN_HOOK_PYLINT_RCFILE, CONAN_HOOK_PYLINT_WERR
+from tests.utils.test_cases.conan_client import ConanClientTestCase
+
+
+class RecipeLinterTests(ConanClientTestCase):
+    conanfile = textwrap.dedent("""\
+        from conans import ConanFile, tools
+        
+        class TestConan(ConanFile):
+            name = "name"
+            version = "version"
+            
+            def build(self):
+                print("Hello world")    
+                for k, v in {}.iteritems():
+                    pass
+                tools.msvc_build_command(self.settings, "path")
+        """)
+
+    def _get_environ(self, **kwargs):
+        kwargs = super(RecipeLinterTests, self)._get_environ(**kwargs)
+        kwargs.update({'CONAN_HOOKS': os.path.join(os.path.dirname(
+            __file__), '..', '..', 'hooks', 'recipe_linter')})
+        return kwargs
+
+    @parameterized.expand([(False, ), (True, )])
+    def test_basic(self, pylint_werr):
+        tools.save('conanfile.py', content=self.conanfile)
+        pylint_werr_value = "1" if pylint_werr else None
+        with environment_append({CONAN_HOOK_PYLINT_WERR: pylint_werr_value}):
+            return_code = ERROR_GENERAL if pylint_werr else SUCCESS
+            output = self.conan(['export', '.', 'name/version@'], expected_return_code=return_code)
+
+            if pylint_werr:
+                self.assertIn("pre_export(): Package recipe has linter errors."
+                              " Please fix them.", output)
+
+            if six.PY2:
+                self.assertIn("ERROR: Py3 incompatibility. Line 7: print statement used", output)
+                self.assertIn("ERROR: Py3 incompatibility. Line 8: Calling a dict.iter*() method", output)
+
+            self.assertIn("pre_export(): conanfile.py:9:20:"
+                          " W1620: Calling a dict.iter*() method (dict-iter-method)", output)
+            self.assertIn("pre_export(): conanfile.py:9:20:"
+                          " E1101: Instance of 'dict' has no 'iteritems' member (no-member)", output)
+            self.assertIn("pre_export(): conanfile.py:9:12:"
+                          " W0612: Unused variable 'k' (unused-variable)", output)
+            self.assertIn("pre_export(): conanfile.py:9:15:"
+                          " W0612: Unused variable 'v' (unused-variable)", output)
+
+    def test_custom_rcfile(self):
+        tools.save('conanfile.py', content=self.conanfile)
+        tools.save('pylintrc', content="[FORMAT]\nindent-string='  '")
+
+        with environment_append({CONAN_HOOK_PYLINT_RCFILE: os.path.join(os.getcwd(), "pylintrc")}):
+            output = self.conan(['export', '.', 'name/version@'])
+
+        self.assertIn("pre_export(): conanfile.py:4:0:"
+                      " W0311: Bad indentation. Found 4 spaces, expected 2 (bad-indentation)", output)
+
+    def test_dynamic_fields(self):
+        conanfile = textwrap.dedent( """
+            from conans import ConanFile, python_requires
+            
+            base = python_requires("name/version")
+            
+            class TestConan(ConanFile):
+                name = "consumer"
+                version = "version"
+                
+                def build(self):
+                    self.output.info(self.source_folder)
+                    self.output.info(self.package_folder)
+                    self.output.info(self.build_folder)
+                    self.output.info(self.install_folder)
+                    
+                def package(self):
+                    self.copy("*")
+                    
+                def package_id(self):
+                    self.info.header_only()
+                    
+                def build_id(self):
+                    self.output.info(str(self.info_build))
+                    
+                def build_requirements(self):
+                    self.build_requires("name/version")
+                    
+                def requirements(self):
+                    self.requires("name/version")
+                    
+                def deploy(self):
+                    self.copy_deps("*.dll")
+            """)
+        tools.save('require.py', self.conanfile)
+        self.conan(['export', 'require.py', 'name/version@'])
+
+        tools.save('consumer.py', content=conanfile)
+        with environment_append({CONAN_HOOK_PYLINT_WERR: "1"}):
+            output = self.conan(['export', 'consumer.py', 'consumer/version@'])
+            self.assertIn("pre_export(): Lint recipe", output)  # Hook run without errors
+            self.assertNotIn("(no-member)", output)
+
+    def test_catch_them_all(self):
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
+            class BaseConan(ConanFile):
+
+                def source(self):
+                    try:
+                        raise Exception("Pikaaaaa!!")
+                    except:
+                        print("I got pikachu!!")
+                    try:
+                        raise Exception("Pikaaaaa!!")
+                    except Exception:
+                        print("I got pikachu!!")
+            """)
+
+        tools.save('conanfile.py', content=conanfile)
+        with environment_append({CONAN_HOOK_PYLINT_WERR: "1"}):
+            output = self.conan(['export', '.', 'consumer/version@'])
+            self.assertIn("pre_export(): Lint recipe", output)  # Hook run without errors
+            self.assertNotIn("no-member", output)
+            self.assertNotIn("bare-except", output)
+            self.assertNotIn("broad-except", output)
+
+    def test_conan_data(self):
+        conanfile = textwrap.dedent("""
+            from conans import ConanFile
+        
+            class ExampleConan(ConanFile):
+    
+                def build(self):
+                    print(self.conan_data["sources"][float(self.version)])
+            """)
+        tools.save('conanfile.py', content=conanfile)
+        with environment_append({CONAN_HOOK_PYLINT_WERR: "1"}):
+            output = self.conan(['export', '.', 'consumer/version@'])
+            self.assertIn("pre_export(): Lint recipe", output)  # Hook run without errors
+            self.assertNotIn("no-member", output)
+

--- a/tests/test_hooks/test_recipe_linter.py
+++ b/tests/test_hooks/test_recipe_linter.py
@@ -46,8 +46,10 @@ class RecipeLinterTests(ConanClientTestCase):
                               " Please fix them.", output)
 
             if six.PY2:
-                self.assertIn("ERROR: Py3 incompatibility. Line 7: print statement used", output)
-                self.assertIn("ERROR: Py3 incompatibility. Line 8: Calling a dict.iter*() method", output)
+                self.assertIn("pre_export(): conanfile.py:8:8:"
+                              " E1601: print statement used (print-statement)", output)
+                self.assertIn("pre_export(): conanfile.py:9:20:"
+                              " W1620: Calling a dict.iter*() method (dict-iter-method)", output)
 
             self.assertIn("pre_export(): conanfile.py:9:20:"
                           " W1620: Calling a dict.iter*() method (dict-iter-method)", output)

--- a/tests/test_hooks/test_recipe_linter.py
+++ b/tests/test_hooks/test_recipe_linter.py
@@ -48,13 +48,13 @@ class RecipeLinterTests(ConanClientTestCase):
             if six.PY2:
                 self.assertIn("pre_export(): conanfile.py:8:8:"
                               " E1601: print statement used (print-statement)", output)
+            else:
                 self.assertIn("pre_export(): conanfile.py:9:20:"
-                              " W1620: Calling a dict.iter*() method (dict-iter-method)", output)
+                              " E1101: Instance of 'dict' has no 'iteritems' member (no-member)",
+                              output)
 
             self.assertIn("pre_export(): conanfile.py:9:20:"
                           " W1620: Calling a dict.iter*() method (dict-iter-method)", output)
-            self.assertIn("pre_export(): conanfile.py:9:20:"
-                          " E1101: Instance of 'dict' has no 'iteritems' member (no-member)", output)
             self.assertIn("pre_export(): conanfile.py:9:12:"
                           " W0612: Unused variable 'k' (unused-variable)", output)
             self.assertIn("pre_export(): conanfile.py:9:15:"

--- a/tests/test_hooks/test_recipe_linter.py
+++ b/tests/test_hooks/test_recipe_linter.py
@@ -16,7 +16,7 @@ from tests.utils.test_cases.conan_client import ConanClientTestCase
 
 
 class RecipeLinterTests(ConanClientTestCase):
-    conanfile = textwrap.dedent("""\
+    conanfile = textwrap.dedent("""
         from conans import ConanFile, tools
         
         class TestConan(ConanFile):
@@ -49,18 +49,18 @@ class RecipeLinterTests(ConanClientTestCase):
                               " Please fix them.", output)
 
             if six.PY2:
-                self.assertIn("pre_export(): conanfile.py:8:8:"
+                self.assertIn("pre_export(): conanfile.py:9:8:"
                               " E1601: print statement used (print-statement)", output)
             else:
-                self.assertIn("pre_export(): conanfile.py:9:20:"
+                self.assertIn("pre_export(): conanfile.py:10:20:"
                               " E1101: Instance of 'dict' has no 'iteritems' member (no-member)",
                               output)
 
-            self.assertIn("pre_export(): conanfile.py:9:20:"
+            self.assertIn("pre_export(): conanfile.py:10:20:"
                           " W1620: Calling a dict.iter*() method (dict-iter-method)", output)
-            self.assertIn("pre_export(): conanfile.py:9:12:"
+            self.assertIn("pre_export(): conanfile.py:10:12:"
                           " W0612: Unused variable 'k' (unused-variable)", output)
-            self.assertIn("pre_export(): conanfile.py:9:15:"
+            self.assertIn("pre_export(): conanfile.py:10:15:"
                           " W0612: Unused variable 'v' (unused-variable)", output)
 
     def test_custom_rcfile(self):
@@ -70,7 +70,7 @@ class RecipeLinterTests(ConanClientTestCase):
         with environment_append({"CONAN_PYLINTRC": os.path.join(os.getcwd(), "pylintrc")}):
             output = self.conan(['export', '.', 'name/version@'])
 
-        self.assertIn("pre_export(): conanfile.py:4:0: "
+        self.assertIn("pre_export(): conanfile.py:5:0: "
                       "W0311: Bad indentation. Found 4 spaces, expected 2 (bad-indentation)", output)
 
     def test_custom_plugin(self):

--- a/tests/test_hooks/test_recipe_linter.py
+++ b/tests/test_hooks/test_recipe_linter.py
@@ -16,7 +16,7 @@ from tests.utils.test_cases.conan_client import ConanClientTestCase
 
 
 class RecipeLinterTests(ConanClientTestCase):
-    conanfile = textwrap.dedent("""
+    conanfile = textwrap.dedent(r"""
         from conans import ConanFile, tools
         
         class TestConan(ConanFile):
@@ -74,7 +74,7 @@ class RecipeLinterTests(ConanClientTestCase):
                       "W0311: Bad indentation. Found 4 spaces, expected 2 (bad-indentation)", output)
 
     def test_custom_plugin(self):
-        conanfile = textwrap.dedent("""
+        conanfile = textwrap.dedent(r"""
             from conans import ConanFile
 
             class Recipe(ConanFile):

--- a/tests/test_hooks/test_recipe_linter.py
+++ b/tests/test_hooks/test_recipe_linter.py
@@ -144,11 +144,11 @@ class RecipeLinterTests(ConanClientTestCase):
                     try:
                         raise Exception("Pikaaaaa!!")
                     except:
-                        print("I got pikachu!!")
+                        pass
                     try:
                         raise Exception("Pikaaaaa!!")
                     except Exception:
-                        print("I got pikachu!!")
+                        pass
             """)
 
         tools.save('conanfile.py', content=conanfile)
@@ -166,7 +166,7 @@ class RecipeLinterTests(ConanClientTestCase):
             class ExampleConan(ConanFile):
     
                 def build(self):
-                    print(self.conan_data["sources"][float(self.version)])
+                    _ = self.conan_data["sources"][float(self.version)]
             """)
         tools.save('conanfile.py', content=conanfile)
         with environment_append({"CONAN_PYLINT_WERR": "1"}):


### PR DESCRIPTION
Add hook to lint recipes. It should substitute Conan built-in (https://github.com/conan-io/conan/pull/6152)

Not to be merged before https://github.com/conan-io/conan/pull/6152, it might require additional requirements in this repo.

- [x] Test `test_dynamic_fields` should only run with the `conans.pylint_plugin.py` with the python_requires added.