### PR TITLE
Only validate cppstd if compiler is specified in settings

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -434,7 +434,7 @@ def post_source(output, conanfile, conanfile_path, **kwargs):
             conanfile_content = tools.load(conanfile_path)
             low = conanfile_content.lower()
 
-            if "del self.settings.compiler.libcxx" not in low:
+            if conanfile.settings.get_safe("compiler") and "del self.settings.compiler.libcxx" not in low:
                 out.error("Can't detect C++ source files but recipe does not remove "
                           "'self.settings.compiler.libcxx'")
 
@@ -443,7 +443,7 @@ def post_source(output, conanfile, conanfile_path, **kwargs):
         if _is_pure_c():
             conanfile_content = tools.load(conanfile_path)
             low = conanfile_content.lower()
-            if "del self.settings.compiler.cppstd" not in low:
+            if conanfile.settings.get_safe("compiler") and "del self.settings.compiler.cppstd" not in low:
                 out.error("Can't detect C++ source files but recipe does not remove "
                           "'self.settings.compiler.cppstd'")
 


### PR DESCRIPTION
Related PR: https://github.com/conan-io/conan-center-index/pull/658#issuecomment-579765701

The idea here is only checking cppstd and libcxx when compiler is defined. Otherwise, that validation should be skipped.