### PR TITLE
Testing using py35 and py38

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,10 @@ jobs:
       python: 3.7
       env: TOXENV=py37-conandev
       dist: xenial
-      sudo: true
+    - name: Python 3.8
+      python: 3.8
+      env: TOXENV=py38-conandev
+      dist: xenial
 
     # All Linux first, check versions
     - stage: Linux - Conan Current
@@ -25,30 +28,38 @@ jobs:
       python: 3.7
       env: TOXENV=py37-conancurrent
       dist: xenial
-      sudo: true
+    - name: Python 3.8
+      python: 3.8
+      env: TOXENV=py38-conancurrent
+      dist: xenial
 
     - stage: Linux - Conan 1.21
       name: Python 3.7
       python: 3.7
       env: TOXENV=py37-conan121
       dist: xenial
-      sudo: true
-
+    - name: Python 3.8
+      python: 3.8
+      env: TOXENV=py38-conan121
+      dist: xenial
 
     - stage: Linux - Conan 1.20
       name: Python 3.7
       python: 3.7
       env: TOXENV=py37-conan120
       dist: xenial
-      sudo: true
+    - name: Python 3.8
+      python: 3.8
+      env: TOXENV=py38-conan120
+      dist: xenial
 
     # Macos is slow, only if everything has passed
     - stage: Macos - All Conan versions
-      name: Conan develop - Python 3.7
+      name: Conan develop - Python 3.8
       language: generic
       os: osx
       osx_image: xcode11.2
-      env: PYVER=py37 TOXENV=py37-conandev
+      env: PYVER=py38 TOXENV=py38-conandev
     - name: Conan Current - Python 2.7
       language: generic
       os: osx
@@ -59,6 +70,11 @@ jobs:
       os: osx
       osx_image: xcode11.2
       env: PYVER=py37 TOXENV=py37-conancurrent
+    - name: Conan Current - Python 3.8
+      language: generic
+      os: osx
+      osx_image: xcode11.2
+      env: PYVER=py38 TOXENV=py38-conancurrent
 
 before_install:
   - ./.travis/before_install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ jobs:
       name: Python 2.7
       python: 2.7
       env: TOXENV=py27-conandev
-    - name: Python 3.7
-      python: 3.7
-      env: TOXENV=py37-conandev
+    - name: Python 3.5
+      python: 3.5
+      env: TOXENV=py35-conandev
       dist: xenial
     - name: Python 3.8
       python: 3.8
@@ -24,9 +24,9 @@ jobs:
       name: Python 2.7
       python: 2.7
       env: TOXENV=py27-conancurrent
-    - name: Python 3.7
-      python: 3.7
-      env: TOXENV=py37-conancurrent
+    - name: Python 3.5
+      python: 3.5
+      env: TOXENV=py35-conancurrent
       dist: xenial
     - name: Python 3.8
       python: 3.8
@@ -34,9 +34,9 @@ jobs:
       dist: xenial
 
     - stage: Linux - Conan 1.21
-      name: Python 3.7
-      python: 3.7
-      env: TOXENV=py37-conan121
+      name: Python 3.5
+      python: 3.5
+      env: TOXENV=py35-conan121
       dist: xenial
     - name: Python 3.8
       python: 3.8
@@ -44,9 +44,9 @@ jobs:
       dist: xenial
 
     - stage: Linux - Conan 1.20
-      name: Python 3.7
-      python: 3.7
-      env: TOXENV=py37-conan120
+      name: Python 3.5
+      python: 3.5
+      env: TOXENV=py35-conan120
       dist: xenial
     - name: Python 3.8
       python: 3.8
@@ -65,11 +65,11 @@ jobs:
       os: osx
       osx_image: xcode11.2
       env: PYVER=py27 TOXENV=py27-conancurrent
-    - name: Conan Current - Python 3.7
+    - name: Conan Current - Python 3.5
       language: generic
       os: osx
       osx_image: xcode11.2
-      env: PYVER=py37 TOXENV=py37-conancurrent
+      env: PYVER=py35 TOXENV=py35-conancurrent
     - name: Conan Current - Python 3.8
       language: generic
       os: osx

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -14,28 +14,28 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
 
     case "${PYVER}" in
         py27)
-            pyenv install 2.7.16
-            pyenv virtualenv 2.7.16 conan
+            pyenv install 2.7.17
+            pyenv virtualenv 2.7.17 conan
             ;;
         py33)
-            pyenv install 3.3.6
-            pyenv virtualenv 3.3.6 conan
+            pyenv install 3.3.7
+            pyenv virtualenv 3.3.7 conan
             ;;
         py34)
-            pyenv install 3.4.3
-            pyenv virtualenv 3.4.3 conan
+            pyenv install 3.4.10
+            pyenv virtualenv 3.4.10 conan
             ;;
         py35)
-            pyenv install 3.5.0
-            pyenv virtualenv 3.5.0 conan
+            pyenv install 3.5.9
+            pyenv virtualenv 3.5.9 conan
             ;;
         py36)
-            pyenv install 3.6.0
-            pyenv virtualenv 3.6.0 conan
+            pyenv install 3.6.10
+            pyenv virtualenv 3.6.10 conan
             ;;
         py37)
-            pyenv install 3.7.0
-            pyenv virtualenv 3.7.0 conan
+            pyenv install 3.7.6
+            pyenv virtualenv 3.7.6 conan
             ;;
         py38)
             pyenv install 3.8.1

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -37,6 +37,10 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
             pyenv install 3.7.0
             pyenv virtualenv 3.7.0 conan
             ;;
+        py38)
+            pyenv install 3.8
+            pyenv virtualenv 3.8 conan
+            ;;
 
     esac
     pyenv rehash

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -38,8 +38,8 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
             pyenv virtualenv 3.7.0 conan
             ;;
         py38)
-            pyenv install 3.8
-            pyenv virtualenv 3.8 conan
+            pyenv install 3.8.1
+            pyenv virtualenv 3.8.1 conan
             ;;
 
     esac

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,20 +9,24 @@ environment:
           TOXENV: py27-conandev
         - PYVER: py37
           TOXENV: py37-conandev
+        - PYVER: py38
+          TOXENV: py38-conandev
 
         # Conan current version
         - PYVER: py27
           TOXENV: py27-conancurrent
         - PYVER: py37
           TOXENV: py37-conancurrent
+        - PYVER: py38
+          TOXENV: py38-conancurrent
 
         # Conan 1.21.x
-        - PYVER: py37
-          TOXENV: py37-conan121
+        - PYVER: py38
+          TOXENV: py38-conan121
 
         # Conan 1.20.x
-        - PYVER: py37
-          TOXENV: py37-conan120
+        - PYVER: py38
+          TOXENV: py38-conan120
 
 install:
   - set PATH=%PATH%;%PYTHON%/Scripts/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,16 +7,16 @@ environment:
         # Conan development
         - PYVER: py27
           TOXENV: py27-conandev
-        - PYVER: py37
-          TOXENV: py37-conandev
+        - PYVER: py35
+          TOXENV: py35-conandev
         - PYVER: py38
           TOXENV: py38-conandev
 
         # Conan current version
         - PYVER: py27
           TOXENV: py27-conancurrent
-        - PYVER: py37
-          TOXENV: py37-conancurrent
+        - PYVER: py35
+          TOXENV: py35-conancurrent
         - PYVER: py38
           TOXENV: py38-conancurrent
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skipsdist=True
 envlist =
-    py{27,37}-conan{dev,latest,120,121}
+    py{27,37,38}-conan{dev,latest,120,121}
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skipsdist=True
 envlist =
-    py{27,37,38}-conan{dev,latest,120,121}
+    py{27,35,37,38}-conan{dev,latest,120,121}
 
 [testenv]
 deps =


### PR DESCRIPTION
I've many doubts about the versions we should use in this CI, what do you think?
 * Windows users will likely install the latest Python available, so they will be using py38 or py37 depending on when they did install their system
 * Unix users might use the one installed in the system, and it could be py3.5 😕 

wdyt? Do we care about old versions? Just test with the _latest_? Only two _latest_ versions? Try to resemble the ecosystem out there?

Meanwhile, I want to know if these hooks works with py38 or there is any issue.