### PR TITLE
Fix CI for Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,10 @@ install:
       pyenv activate conan;
     fi
   - pip install --upgrade pip
-  - pip uninstall -y -r <(pip freeze)
+  - |
+    if [[ "$(pip freeze)" ]]; then
+      pip uninstall -y -r <(pip freeze);
+    fi
   - pip install -r .travis/requirements_travis.txt
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,7 @@ install:
       pyenv activate conan;
     fi
   - pip install --upgrade pip
+  - pip uninstall -y -r <(pip freeze)
   - pip install -r .travis/requirements_travis.txt
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,6 @@ install:
       pyenv activate conan;
     fi
   - pip install --upgrade pip
-  - pip install tox tox-venv
   - pip install -r .travis/requirements_travis.txt
 
 script:

--- a/.travis/requirements_travis.txt
+++ b/.travis/requirements_travis.txt
@@ -1,3 +1,3 @@
 tox
 tox-venv
-virtualenv==16.7.9  # TODO: Remove when dropping Python 2
+virtualenv<=16.7.9  # TODO: Remove when dropping Python 2

--- a/.travis/requirements_travis.txt
+++ b/.travis/requirements_travis.txt
@@ -1,2 +1,2 @@
 tox-travis
-six==1.12.0
+six==1.13.0

--- a/.travis/requirements_travis.txt
+++ b/.travis/requirements_travis.txt
@@ -1,2 +1,3 @@
-tox-travis
+tox
+tox-venv
 virtualenv==16.7.9  # TODO: Remove when dropping Python 2

--- a/.travis/requirements_travis.txt
+++ b/.travis/requirements_travis.txt
@@ -1,2 +1,1 @@
 tox-travis
-six==1.14.0

--- a/.travis/requirements_travis.txt
+++ b/.travis/requirements_travis.txt
@@ -1,1 +1,2 @@
 tox-travis
+six==1.12.0

--- a/.travis/requirements_travis.txt
+++ b/.travis/requirements_travis.txt
@@ -1,2 +1,2 @@
 tox-travis
-six==1.13.0
+six==1.14.0

--- a/.travis/requirements_travis.txt
+++ b/.travis/requirements_travis.txt
@@ -1,1 +1,2 @@
 tox-travis
+virtualenv==16.7.9  # TODO: Remove when dropping Python 2

--- a/tests/requirements_test.txt
+++ b/tests/requirements_test.txt
@@ -4,4 +4,3 @@ responses
 pluggy==0.11.0
 pylint
 astroid
-six>=1.10.0,<=1.14.0

--- a/tests/requirements_test.txt
+++ b/tests/requirements_test.txt
@@ -4,3 +4,4 @@ responses
 pluggy==0.11.0
 pylint
 astroid
+six>=1.10.0,<=1.14.0


### PR DESCRIPTION
Seems there was a major change in virtualenv when they bumped the version to 20.0.0 - For some reason this caused the pyenv creation to fail only in Python 2.

This is a temporal fix for it until we drop Python 2 support from testing.

---------------

closes #155 