### PR TITLE
Check final newline of selected file types (KB-H041)

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -384,7 +384,7 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
         def _check_final_newline(path):
             try:
                 last_char = tools.load(path)[-1]
-            except OSError:
+            except (OSError, IndexError):
                 return  # File is empty ==> ignore
             if last_char not in ("\n", "\r"):
                 out.error("File '{}' does not end with an endline".format(path))

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -376,21 +376,23 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
 
     @run_test("KB-H041", output)
     def test(out):
-        checked_fileexts = ".c", ".cc", ".cpp", ".cxx", ".h", ".hxx", ".hpp", ".py", ".txt", ".yml", ".cmake"
+        checked_fileexts = ".c", ".cc", ".cpp", ".cxx", ".h", ".hxx", ".hpp", \
+                           ".py", ".txt", ".yml", ".cmake", ".xml", ".patch", ".md"
+
+        files_noext = "Makefile", "GNUMakefile"
 
         def _check_final_newline(path):
-            with open(path, "rb") as f:
-                try:
-                    f.seek(-1, 2)  # Move to last byte
-                except OSError:
-                    return  # File is empty ==> ignore
-                if f.read(1) not in (b'\n', '\r'):
-                    out.error("File '{}' does not end with an endline".format(path))
+            try:
+                last_char = tools.load(path)[-1]
+            except OSError:
+                return  # File is empty ==> ignore
+            if last_char not in ("\n", "\r"):
+                out.error("File '{}' does not end with an endline".format(path))
 
         for root, _, filenames in os.walk(export_folder_path):
             for filename in filenames:
                 _, fileext = os.path.splitext(filename)
-                if fileext.lower() in checked_fileexts:
+                if filename in files_noext or fileext.lower() in checked_fileexts:
                     _check_final_newline(os.path.join(root, filename))
 
         config_yml = os.path.join(export_folder_path, os.path.pardir, "config.yml")

--- a/tests/test_hooks/conan-center/test_final_newline.py
+++ b/tests/test_hooks/conan-center/test_final_newline.py
@@ -1,0 +1,95 @@
+import os
+import textwrap
+
+from conans import tools
+
+from tests.utils.test_cases.conan_client import ConanClientTestCase
+
+
+class TestGlobalFinalNewLine(ConanClientTestCase):
+    conanfile = textwrap.dedent("""\
+        from conans import ConanFile
+
+        class AConan(ConanFile):
+            pass
+        """)
+
+    cmakelists = textwrap.dedent("""\
+        cmake_minimum_required(VERSION 3.0)
+        project(someproject)
+        
+        include(conanbuildinfo.cmake)
+        conan_basic_setup()
+        
+        add_subdirectory(source_subfolder)
+        """)
+
+    csource = textwrap.dedent("""\
+        #include <stdio.h>
+        int main() {
+            printf("Hello world\\n");
+            return 0;
+        }
+        """)
+
+    conandata_yml = textwrap.dedent("""\
+        sources:
+          3.14:
+            url: "http://example.com/download/release-3.14.tar.gz"
+            sha256: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        """)
+
+    config_yml = textwrap.dedent("""\
+        versions:
+          3.14:
+            folder:all
+        """)
+
+    def _get_environ(self, **kwargs):
+        kwargs = super(TestGlobalFinalNewLine, self)._get_environ(**kwargs)
+        kwargs.update({'CONAN_HOOKS': os.path.join(os.path.dirname(__file__), '..', '..', '..',
+                                                   'hooks', 'conan-center')})
+        return kwargs
+
+    def test_no_newline_pysoure(self):
+        tools.save('conanfile.py', content=self.conanfile.strip())
+        output = self.conan(['export', '.', 'name/version@user/channel'])
+        self.assertIn("ERROR: [NO FINAL ENDLINE (KB-H041)]", output)
+        self.assertIn("does not end with an endline", output)
+
+    def test_no_newline_cmakelists(self):
+        tools.save('conanfile.py', content=self.conanfile)
+        tools.save(os.path.join('CMakeLists.txt'), content=self.cmakelists.strip())
+        output = self.conan(['export', '.', 'name/version@user/channel'])
+        self.assertIn("ERROR: [NO FINAL ENDLINE (KB-H041)]", output)
+        self.assertIn("does not end with an endline", output)
+
+    def test_no_newline_csource(self):
+        tools.save('conanfile.py', content=self.conanfile)
+        tools.save(os.path.join('test_package', 'test_package.c'), content=self.csource.strip())
+        output = self.conan(['export', '.', 'name/version@user/channel'])
+        self.assertIn("ERROR: [NO FINAL ENDLINE (KB-H041)]", output)
+        self.assertIn("does not end with an endline", output)
+
+    def test_no_newline_yml(self):
+        tools.save('conanfile.py', content=self.conanfile)
+        tools.save(os.path.join('conandata.yml'), content=self.conandata_yml.strip())
+        output = self.conan(['export', '.', 'name/version@user/channel'])
+        self.assertIn("ERROR: [NO FINAL ENDLINE (KB-H041)]", output)
+        self.assertIn("does not end with an endline", output)
+
+    def test_no_newline_config_yml(self):
+        tools.save(os.path.join('all', 'conanfile.py'), content=self.conanfile)
+        tools.save(os.path.join('config.yml'), content=self.config_yml.strip())
+        output = self.conan(['export', 'all', 'name/version@user/channel'])
+        self.assertIn("ERROR: [NO FINAL ENDLINE (KB-H041)]", output)
+        self.assertIn("does not end with an endline", output)
+
+    def test_ok_usage(self):
+        tools.save(os.path.join('config.yml'), content=self.config_yml)
+        tools.save(os.path.join('all', 'conanfile.py'), content=self.conanfile)
+        tools.save(os.path.join('all', 'CMakeLists.txt'), content=self.cmakelists)
+        tools.save(os.path.join('all', 'test_package', 'test_package.c'), content=self.csource)
+        tools.save(os.path.join('all', 'conandata.yml'), content=self.conandata_yml)
+        output = self.conan(['export', 'all', 'name/version@user/channel'])
+        self.assertNotIn("ERROR: [NO FINAL ENDLINE (KB-H041)]", output)


### PR DESCRIPTION
In response to discussion at https://github.com/conan-io/conan-center-index/pull/910#discussion_r381538273

closes #159

WIKI:

**#KB-H041: "NO FINAL ENDLINE"**

Source files should end with a final endline.
This avoid potential warnings/errors like `no new line at the end of file`.