### PR TITLE
Test for missing system_libs (KB-H043)

### DIFF
--- a/.ci/requirements_linux.txt
+++ b/.ci/requirements_linux.txt
@@ -1,3 +1,4 @@
 tox
 tox-venv
 requests
+cmake

--- a/.ci/requirements_macos.txt
+++ b/.ci/requirements_macos.txt
@@ -1,3 +1,4 @@
 tox
 tox-venv
 requests
+cmake

--- a/.ci/run_tox.sh
+++ b/.ci/run_tox.sh
@@ -20,5 +20,8 @@ case "${PYVER}" in
         ;;
 esac
 
+TEST_FOLDER=${TMPDIR}/${PYVER}
+source ${TEST_FOLDER}/bin/activate
+
 ${PYVER} -m tox --recreate
 

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1354,7 +1354,6 @@ def _deplibs_from_shlibs(conanfile, out):
                             out.warn("Library dependency '{}' of '{}' has a non-standard name.".format(name, library))
                             continue
                         deplibs.setdefault(match.group(1), []).append(library)
-                x = 0
             else:
                 dep_libs_fn = list(l.replace("NEEDED", "").strip() for l in objdump_output.splitlines() if "NEEDED" in l)
                 for dep_lib_fn in dep_libs_fn:

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1326,7 +1326,6 @@ def _deplibs_from_shlibs(conanfile, out):
                 out.warn("Running objdump on '{}' failed. Is the environment variable OBJDUMP correctly configured?".format(library))
                 continue
             if _get_os(conanfile) == "Windows":
-                open("output.txt", "w").write(objdump_output)
                 for dep_lib_match in re.finditer(r"DLL Name: (.*).dll", objdump_output, re.IGNORECASE):
                     dep_lib_base = dep_lib_match.group(1).lower()
                     deplibs.setdefault(dep_lib_base, []).append(library)

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1079,7 +1079,7 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
 
         missing_system_libs = needed_system_libs.difference(deps_system_libs.union(conanfile_system_libs))
 
-        attribute = 'frameworks' if _get_os(conanfile) else 'system_libs'
+        attribute = 'frameworks' if _get_os(conanfile) == "Macos" else 'system_libs'
         for missing_system_lib in missing_system_libs:
             libs = dict_deplibs_libs[missing_system_lib]
             for lib in libs:

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1,10 +1,13 @@
 import ast
 import collections
+
 import fnmatch
 import inspect
 import os
 import re
 import sys
+import subprocess
+
 from logging import WARNING, ERROR, INFO, DEBUG, NOTSET
 
 import yaml
@@ -52,6 +55,7 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H039": "NOT ALLOWED ATTRIBUTES",
              "KB-H040": "NO TARGET NAME",
              "KB-H041": "NO FINAL ENDLINE",
+             "KB-H043": "MISSING SYSTEM LIBS",
              "KB-H044": "NO REQUIRES.ADD()",
              "KB-H045": "DELETE OPTIONS",
              "KB-H046": "CMAKE VERBOSE MAKEFILE",
@@ -1057,6 +1061,27 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
     def test(out):
         _check_short_paths(conanfile_path, conanfile.package_folder, 160, out)
 
+    @run_test("KB-H043", output)
+    def test(out):
+        if tools.is_apple_os(_get_os(conanfile)):
+            out.info("apple os not supported")
+            return
+        dict_deplibs_libs = _deplibs_from_shlibs(conanfile, out)
+        all_system_libs = _all_system_libs(_get_os(conanfile))
+
+        needed_system_libs = set(dict_deplibs_libs.keys()).intersection(all_system_libs)
+
+        deps_system_libs = set(conanfile.deps_cpp_info.system_libs)
+
+        conanfile_system_libs = set(m.group(2) for m in re.finditer(r"""(["'])([a-zA-Z0-9._-]+)(\1)""", tools.load(conanfile_path))).intersection(all_system_libs)
+
+        missing_system_libs = needed_system_libs.difference(deps_system_libs.union(conanfile_system_libs))
+
+        for missing_system_lib in missing_system_libs:
+            libs = dict_deplibs_libs[missing_system_lib]
+            for lib in libs:
+                out.warn("Library '{}' links to system library '{}' but it is not in cpp_info.system_libs.".format(lib, missing_system_lib))
+
 
 @raise_if_error_output
 def post_package_info(output, conanfile, reference, **kwargs):
@@ -1091,7 +1116,6 @@ def post_package_info(output, conanfile, reference, **kwargs):
             out.warn("The *.cmake files have to be placed in a folder declared as "
                      "`cpp_info.builddirs`. Currently folders declared: {}".format(build_dirs))
             out.warn("Found files: {}".format("; ".join(files_missplaced)))
-
 
     @run_test("KB-H054", output)
     def test(out):
@@ -1255,3 +1279,112 @@ def _check_short_paths(conanfile_path, folder_path, max_length_path, output):
                             f"The file '{filepath}' has a very long path and may exceed Windows max path length. "
                             "Add 'short_paths = True' in your recipe.")
                         break
+
+def _get_compiler(conanfile):
+    settings = _get_settings(conanfile)
+    if not settings:
+        return None
+    return settings.get_safe("compiler")
+
+
+def _all_system_libs(os_):
+    if os_ == "Linux":
+        return _GLIBC_LIBS
+    elif os_ == "Windows":
+        return _WIN32_LIBS
+    else:
+        return []
+
+
+def _deplibs_from_shlibs(conanfile, out):
+    deplibs = dict()
+    os_ = _get_os(conanfile)
+    shlext = {
+        "Windows": "dll",
+        "Macos": "dylib"
+    }.get(os_, "so")
+    libraries = _get_files_with_extensions(conanfile.package_folder, [shlext])
+    if not libraries:
+        return deplibs
+    if os_ == "Linux" or tools.is_apple_os(os_) or _get_compiler(conanfile) != "Visual Studio":
+        objdump = tools.get_env("OBJDUMP") or tools.which("objdump")
+        if not objdump:
+            out.warn("objdump not found")
+            return
+        for library in libraries:
+            if _get_os(conanfile) == "Windows":
+                cmd = [objdump, "--section=.idata", "-x", library]
+            else:
+                cmd = [objdump, "-p", library]
+            try:
+                objdump_output = subprocess.check_output(cmd, cwd=conanfile.package_folder).decode()
+            except subprocess.CalledProcessError:
+                out.warn("Running objdump on '{}' failed. Is the environment variable OBJDUMP correctly configured?".format(library))
+                continue
+            if _get_os(conanfile) == "Windows":
+                open("output.txt", "w").write(objdump_output)
+                for dep_lib_match in re.finditer(r"DLL Name: (.*).dll", objdump_output, re.IGNORECASE):
+                    dep_lib_base = dep_lib_match.group(1).lower()
+                    deplibs.setdefault(dep_lib_base, []).append(library)
+            else:
+                dep_libs_fn = list(l.replace("NEEDED", "").strip() for l in objdump_output.splitlines() if "NEEDED" in l)
+                for dep_lib_fn in dep_libs_fn:
+                    dep_lib_match = re.match(r"lib(.*).{}(?:\.[0-9]+)*".format(shlext), dep_lib_fn)
+                    if not dep_lib_match:
+                        out.warn("Library dependency '{}' of '{}' has a non-standard name.".format(dep_lib_fn, library))
+                        continue
+                    deplibs.setdefault(dep_lib_match.group(1), []).append(library)
+    elif _get_compiler(conanfile) == "Visual Studio" or _get_os == "Windows":
+        with tools.vcvars(conanfile.settings):
+            for library in libraries:
+                try:
+                    dumpbin_output = subprocess.check_output(["dumpbin", "-dependents", library], cwd=conanfile.package_folder).decode()
+                except subprocess.CalledProcessError:
+                    out.warn("Running dumpbin on '{}' failed.".format(library))
+                    continue
+                print("OUTPUT:", dumpbin_output)
+                for l in re.finditer(r"([a-z0-9\-_]+)\.dll", dumpbin_output, re.IGNORECASE):
+                    dep_lib_base = l.group(1).lower()
+                    deplibs.setdefault(dep_lib_base, []).append(library)
+    return deplibs
+
+
+_GLIBC_LIBS = {
+    "anl", "BrokenLocale", "crypt", "dl", "g", "m", "mvec", "nsl", "nss_compat", "nss_db", "nss_dns",
+    "nss_files", "nss_hesiod", "pthread", "resolv", "rt", "thread_db", "util",
+}
+
+_WIN32_LIBS = {
+    "aclui", "activeds", "adsiid", "advapi32", "advpack", "ahadmin", "amstrmid", "authz", "aux_ulib",
+    "avifil32", "avrt", "bcrypt", "bhsupp", "bits", "bthprops", "cabinet", "certadm", "certidl",
+    "certpoleng", "clfsmgmt", "clfsw32", "clusapi", "comctl32", "comdlg32", "comsvcs", "corguids",
+    "correngine", "credui", "crypt32", "cryptnet", "cryptui", "cryptxml", "cscapi", "d2d1", "d3d10",
+    "d3d10_1", "d3d11", "d3d8thk", "d3d9", "davclnt", "dbgeng", "dbghelp", "dciman32", "dhcpcsvc",
+    "dhcpcsvc6", "dhcpsapi", "dinput8", "dmoguids", "dnsapi", "dpx", "drt", "drtprov", "drttransport",
+    "dsound", "dsprop", "dsuiext", "dtchelp", "dwrite", "dxgi", "dxva2", "eappcfg", "eappprxy",
+    "ehstorguids", "elscore", "esent", "evr", "evr_vista", "faultrep", "fci", "fdi", "fileextd", "fontsub",
+    "format", "framedyd", "framedyn", "fwpuclnt", "fxsutility", "gdi32", "gdiplus", "gpedit", "gpmuuid",
+    "hlink", "htmlhelp", "httpapi", "icm32", "icmui", "iepmapi", "imagehlp", "imgutil", "imm32",
+    "infocardapi", "iphlpapi", "iprop", "irprops", "kernel32", "ksguid", "ksproxy", "ksuser", "ktmw32",
+    "loadperf", "locationapi", "lz32", "magnification", "mapi32", "mbnapi_uuid", "mf", "mfplat",
+    "mfplat_vista", "mfplay", "mfreadwrite", "mfuuid", "mf_vista", "mgmtapi", "mmc", "mpr", "mqoa", "mqrt",
+    "msacm32", "mscms", "mscoree", "mscorsn", "msctfmonitor", "msdasc", "msdelta", "msdmo", "msdrm", "msi",
+    "msimg32", "mspatchc", "dwmapi", "glu32", "iscsidsc", "mprapi", "msrating", "nmsupp", "prntvpt",
+    "scarddlg", "sisbkup", "wdsbp", "mstask", "msvfw32", "mswsock", "msxml2", "msxml6", "mtx", "mtxdm",
+    "muiload", "ncrypt", "ndfapi", "ndproxystub", "netapi32", "netsh", "newdev", "nmapi", "normaliz",
+    "ntdsapi", "ntmsapi", "ntquery", "odbc32", "odbcbcp", "odbccp32", "ole32", "oleacc", "oleaut32", "oledb",
+    "oledlg", "opengl32", "osptk", "p2p", "p2pgraph", "parser", "pathcch", "pdh", "photoacquireuid",
+    "portabledeviceguids", "powrprof", "propsys", "psapi", "quartz", "qutil", "qwave", "rasapi32", "rasdlg",
+    "resutils", "rpcns4", "rpcrt4", "rstrtmgr", "rtm", "rtutils", "sapi", "sas", "sbtsv", "scrnsave",
+    "scrnsavw", "searchsdk", "secur32", "sensapi", "sensorsapi", "setupapi", "sfc", "shdocvw", "shell32",
+    "shfolder", "shlwapi", "slc", "slcext", "slwga", "snmpapi", "sporder", "srclient", "sti", "strmiids",
+    "strsafe", "structuredquery", "svcguid", "t2embed", "tapi32", "taskschd", "tbs", "tdh", "tlbref",
+    "traffic", "transcodeimageuid", "tspubplugincom", "txfw32", "uiautomationcore", "urlmon", "user32",
+    "userenv", "usp10", "uuid", "uxtheme", "vds_uuid", "version", "vfw32", "virtdisk", "vpccominterfaces",
+    "vssapi", "vss_uuid", "vstorinterface", "wbemuuid", "wcmguid", "wdsclientapi", "wdsmc", "wdspxe",
+    "wdstptc", "webservices", "wecapi", "wer", "wevtapi", "wiaguid", "winbio", "windowscodecs",
+    "windowssideshowguids", "winfax", "winhttp", "wininet", "winmm", "winsatapi", "winscard", "winspool",
+    "winstrm", "wintrust", "wlanapi", "wlanui", "wldap32", "wmcodecdspuuid", "wmdrmsdk", "wmiutils",
+    "wmvcore", "workspaceax", "ws2_32", "wsbapp_uuid", "wscapi", "wsdapi", "wsmsvc", "wsnmp32", "wsock32",
+    "wtsapi32", "wuguid", "xaswitch", "xinput", "xmllite", "xolehlp", "xpsprint",
+}.difference({"kernel32", "user32", "gdi32", "winspool", "shell32", "ole32", "oleaut32", "uuid", "comdlg32", "advapi32"})

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1064,7 +1064,6 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
     @run_test("KB-H043", output)
     def test(out):
         if tools.is_apple_os(_get_os(conanfile)):
-            out.info("apple os not supported")
             return
         dict_deplibs_libs = _deplibs_from_shlibs(conanfile, out)
         all_system_libs = _all_system_libs(_get_os(conanfile))

--- a/tests/requirements_test.txt
+++ b/tests/requirements_test.txt
@@ -6,3 +6,4 @@ pylint==2.10.2
 astroid
 spdx_lookup
 yamllint
+cmake

--- a/tests/requirements_test.txt
+++ b/tests/requirements_test.txt
@@ -6,4 +6,3 @@ pylint==2.10.2
 astroid
 spdx_lookup
 yamllint
-cmake

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -850,7 +850,6 @@ class ConanCenterTests(ConanClientTestCase):
         output = self.conan(['export', '.', 'name/version@user/test'])
         self.assertIn("[CMAKE VERSION REQUIRED (KB-H048)] OK", output)
 
-
     def test_cmake_export_all_symbols_version_required(self):
         conanfile = self.conanfile_base.format(placeholder="exports_sources = \"CMakeLists.txt\"")
         cmake = textwrap.dedent("""

--- a/tests/test_hooks/conan-center/test_missing_system_libs.py
+++ b/tests/test_hooks/conan-center/test_missing_system_libs.py
@@ -168,12 +168,12 @@ class ConanMissingSystemLibs(ConanClientTestCase):
             library = os.path.join(".", self._shlibdir, "libsimplelib.{}".format(self._shlext))
             self.assertIn("[MISSING SYSTEM LIBS (KB-H043)] Library '{library}' links to system library '{syslib}' but it is not in cpp_info.system_libs.".format(library=library, shlext=self._shlext, syslib=lib), output)
 
-    @unittest.skipUnless(not tools.is_apple_os(tools.detected_os()), "Macos is not supported")
     @parameterized.expand([
-        ("shared_dependency", True),
-        ("static_dependency", False),
+        (True,),
+        (False,),
     ])
-    def test_dep_system_lib_ok(self, name, dep_shared):
+    @unittest.skipUnless(not tools.is_apple_os(tools.detected_os()), "Macos is not supported")
+    def test_dep_system_lib_ok(self, dep_shared):
         self._write_files(subdir="dep", name="dep", osbuildinfo=self._os_build_info, system_libs_static=self._os_build_info.shlibs_bases, system_libs_shared=[])
         self.conan(["create", "dep", "dep/version@user/channel", "-o", "dep:shared={}".format(dep_shared)])
         self._write_files(subdir="lib", name="lib", requires=("dep/version@user/channel", ), osbuildinfo=self._os_build_info2, system_libs_static=self._os_build_info2.shlibs_bases, system_libs_shared=[])
@@ -186,11 +186,11 @@ class ConanMissingSystemLibs(ConanClientTestCase):
             library = os.path.join(".", self._shlibdir, "liblib.{}".format(self._shlext))
             self.assertNotIn("[MISSING SYSTEM LIBS (KB-H043)] Library '{library}' links to system library '{syslib}' but it is not in cpp_info.system_libs.".format(library=library, shlext=self._shlext, syslib=lib), output)
 
-    @unittest.skipUnless(not tools.is_apple_os(tools.detected_os()), "Macos is not supported")
     @parameterized.expand([
         ("shared_dependency", True),
         ("static_dependency", False),
     ])
+    @unittest.skipUnless(not tools.is_apple_os(tools.detected_os()), "Macos is not supported")
     def test_dep_system_lib_missing(self, name, dep_shared):
         self._write_files(subdir="dep", name="dep", osbuildinfo=self._os_build_info, system_libs_static=self._os_build_info.shlibs_bases, system_libs_shared=[])
         self.conan(["create", "dep", "dep/version@user/channel", "-o", "dep:shared={}".format(dep_shared)])

--- a/tests/test_hooks/conan-center/test_missing_system_libs.py
+++ b/tests/test_hooks/conan-center/test_missing_system_libs.py
@@ -10,6 +10,7 @@ from conans import __version__ as conan_version
 
 
 @unittest.skipUnless(conan_version >= "1.19.0", "Conan >= 1.19.0 needed")
+@unittest.skipIf(tools.is_apple_os(tools.detected_os()))
 class ConanMissingSystemLibs(ConanClientTestCase):
     cmakelists = textwrap.dedent("""\
         cmake_minimum_required(VERSION 2.8)

--- a/tests/test_hooks/conan-center/test_missing_system_libs.py
+++ b/tests/test_hooks/conan-center/test_missing_system_libs.py
@@ -10,7 +10,7 @@ from conans import __version__ as conan_version
 
 
 @unittest.skipUnless(conan_version >= "1.19.0", "Conan >= 1.19.0 needed")
-@unittest.skipIf(tools.is_apple_os(tools.detected_os()))
+@unittest.skipIf(tools.is_apple_os(tools.detected_os()), "Apple os'es are not supported")
 class ConanMissingSystemLibs(ConanClientTestCase):
     cmakelists = textwrap.dedent("""\
         cmake_minimum_required(VERSION 2.8)

--- a/tests/test_hooks/conan-center/test_missing_system_libs.py
+++ b/tests/test_hooks/conan-center/test_missing_system_libs.py
@@ -1,0 +1,204 @@
+import os
+from parameterized import parameterized
+import textwrap
+import unittest
+
+from conans import tools
+
+from tests.utils.test_cases.conan_client import ConanClientTestCase
+from conans import __version__ as conan_version
+
+
+@unittest.skipUnless(conan_version >= "1.19.0", "Conan >= 1.19.0 needed")
+class ConanMissingSystemLibs(ConanClientTestCase):
+    cmakelists = textwrap.dedent("""\
+        cmake_minimum_required(VERSION 2.8)
+        project(hooks_systemlib_test LANGUAGES C)
+        
+        include(conanbuildinfo.cmake)
+        conan_basic_setup()
+        
+        set(LINK_TO {link_lib})
+        if(LINK_TO)
+            find_library(LINK_LIB_FULL_PATH {link_lib})
+            if(LINK_LIB_FULL_PATH)
+                set(LINK_TO ${{LINK_LIB_FULL_PATH}})
+            endif()
+        endif()
+        
+        add_library({name} simplelib.c)
+        set_property(TARGET {name} PROPERTY PREFIX lib)
+        target_link_libraries({name} ${{LINK_TO}} ${{CONAN_LIBS}})
+        include(GNUInstallDirs)
+        install(TARGETS {name}
+            ARCHIVE DESTINATION ${{CMAKE_INSTALL_LIBDIR}}
+            LIBRARY DESTINATION ${{CMAKE_INSTALL_LIBDIR}}
+            RUNTIME DESTINATION ${{CMAKE_INSTALL_BINDIR}})
+    """)
+
+    source_c = textwrap.dedent("""\
+        #if defined({name}_EXPORTS)
+        #  if defined(_WIN32)
+        #    define API_EXPORTS __declspec(dllexport)
+        #  else
+        #    define API_EXPORTS __attribute__((visibility("default")))
+        #  endif
+        #else
+        #  define API_EXPORTS
+        #endif
+        
+        {includes}
+        
+        API_EXPORTS
+        int {name}_function(int arg) {{
+            {function_call};
+            return 42;
+        }}
+    """)
+
+    conanfile = textwrap.dedent("""\
+        import os
+        from conans import CMake, ConanFile, tools
+
+        class AConan(ConanFile):
+            exports_sources = "CMakeLists.txt", "simplelib.c"
+            settings = "os", "arch", "compiler", "build_type"
+            options = {{"shared": [True, False], "fPIC": [True, False],}}
+            default_options = {{"shared": False, "fPIC": True,}}
+            generators = "cmake"
+            requires = {requires}
+                
+            def package(self):
+                cmake = CMake(self)
+                cmake.configure()
+                cmake.build()
+                cmake.install()
+                
+            def package_info(self):
+                self.cpp_info.libs = ["{name}"]
+                if self.options.shared:
+                    self.cpp_info.system_libs = {system_libs_shared}
+                else:
+                    self.cpp_info.system_libs = {system_libs_static}
+        """)
+
+    conanfile_test = textwrap.dedent("""\
+        from conans import ConanFile
+
+        class AConan(ConanFile):
+            def test(self):
+                pass
+        """)
+
+    class OSBuildInfo(object):
+        def __init__(self, includes, link_libs, shlibs_bases, function):
+            self.includes = includes
+            self.libs = link_libs
+            self.shlibs_bases = shlibs_bases
+            self.function = function
+
+    @property
+    def _os_build_info(self):
+        return {
+            "Linux": self.OSBuildInfo(["dlfcn.h"], ["libdl.so"], ["dl"], "dlclose((void*)0)"),
+            "Windows": self.OSBuildInfo(["winsock.h"], ["ws2_32.lib"], ["ws2_32"], "ntohs(0x4200)"),
+            # "Macos": self.OSBuildInfo([], ["m"], "(int)tan(42.)"),
+        }[tools.detected_os()]
+
+    @property
+    def _os_build_info2(self):
+        return {
+            "Linux": self.OSBuildInfo(["time.h"], ["librt.so"], ["rt"], "clock_settime(CLOCK_REALTIME, 0)"),
+            "Windows": self.OSBuildInfo(["shlwapi.h"], ["shlwapi.lib"], ["shlwapi"], "PathIsDirectory(\"C:\\Windows\")"),
+            # "Macos": self.OSBuildInfo([], ["m"], "(int)tan(42.)"),
+        }[tools.detected_os()]
+
+    @property
+    def _shlext(self):
+        return {
+            "Windows": "dll",
+            "Linux": "so",
+            # "Macos": "dylib",
+        }[tools.detected_os()]
+
+    @property
+    def _shlibdir(self):
+        return {
+            "Windows": "bin",
+            "Linux": "lib",
+            # "Macos": "lib",
+        }[tools.detected_os()]
+
+    def _get_environ(self, **kwargs):
+        kwargs = super(ConanMissingSystemLibs, self)._get_environ(**kwargs)
+        kwargs.update({'CONAN_HOOKS': os.path.join(os.path.dirname(__file__), '..', '..', '..',
+                                                   'hooks', 'conan-center')})
+        return kwargs
+
+    def _write_files(self, osbuildinfo, system_libs_shared, system_libs_static, requires=(), name="simplelib", subdir="."):
+        tools.save(os.path.join(subdir, "conanfile.py"), content=self.conanfile.format(name=name, system_libs_shared=repr(system_libs_shared), system_libs_static=repr(system_libs_static), requires=repr(requires)))
+        tools.save(os.path.join(subdir, "CMakeLists.txt"), content=self.cmakelists.format(name=name, link_lib=" ".join(osbuildinfo.libs)))
+        tools.save(os.path.join(subdir, "simplelib.c"), content=self.source_c.format(name=name, includes="\n".join("#include <{}>".format(include) for include in osbuildinfo.includes), function_call=osbuildinfo.function))
+        tools.save(os.path.join(subdir, "test_package", "conanfile.py"), content=self.conanfile_test)
+
+    def test_no_system_lib(self):
+        osbuildinfo = self.OSBuildInfo([], [], [], "42")
+        self._write_files(osbuildinfo=osbuildinfo, system_libs_static=[], system_libs_shared=[])
+        output = self.conan(["create", ".", "name/version@user/channel", "-o", "name:shared=True"])
+        self.assertIn("[MISSING SYSTEM LIBS (KB-H043)] OK", output)
+        for lib in self._os_build_info.shlibs_bases:
+            library = os.path.join(".", self._shlibdir, "libsimplelib.{}".format(self._shlext))
+            self.assertNotIn("[MISSING SYSTEM LIBS (KB-H043)] Library '{library}' links to system library '{syslib}' but it is not in cpp_info.system_libs.".format(library=library, shlext=self._shlext, syslib=lib), output)
+
+    @unittest.skipUnless(not tools.is_apple_os(tools.detected_os()), "Macos is not supported")
+    def test_system_lib_correct(self):
+        self._write_files(osbuildinfo=self._os_build_info, system_libs_static=self._os_build_info.shlibs_bases, system_libs_shared=[])
+        output = self.conan(["create", ".", "name/version@user/channel", "-o", "name:shared=True"])
+        self.assertIn("[MISSING SYSTEM LIBS (KB-H043)] OK", output)
+        for lib in self._os_build_info.shlibs_bases:
+            library = os.path.join(".", self._shlibdir, "libsimplelib.{}".format(self._shlext))
+            self.assertNotIn("[MISSING SYSTEM LIBS (KB-H043)] Library '{library}' links to system library '{syslib}' but it is not in cpp_info.system_libs.".format(library=library, shlext=self._shlext, syslib=lib), output)
+
+    @unittest.skipUnless(not tools.is_apple_os(tools.detected_os()), "Macos is not supported")
+    def test_system_lib_missing(self):
+        self._write_files(osbuildinfo=self._os_build_info, system_libs_static=[], system_libs_shared=[])
+        output  = self.conan(["create", ".", "name/version@user/channel", "-o", "name:shared=True"])
+        for lib in self._os_build_info.shlibs_bases:
+            library = os.path.join(".", self._shlibdir, "libsimplelib.{}".format(self._shlext))
+            self.assertIn("[MISSING SYSTEM LIBS (KB-H043)] Library '{library}' links to system library '{syslib}' but it is not in cpp_info.system_libs.".format(library=library, shlext=self._shlext, syslib=lib), output)
+
+    @unittest.skipUnless(not tools.is_apple_os(tools.detected_os()), "Macos is not supported")
+    @parameterized.expand([
+        ("shared_dependency", True),
+        ("static_dependency", False),
+    ])
+    def test_dep_system_lib_ok(self, name, dep_shared):
+        self._write_files(subdir="dep", name="dep", osbuildinfo=self._os_build_info, system_libs_static=self._os_build_info.shlibs_bases, system_libs_shared=[])
+        self.conan(["create", "dep", "dep/version@user/channel", "-o", "dep:shared={}".format(dep_shared)])
+        self._write_files(subdir="lib", name="lib", requires=("dep/version@user/channel", ), osbuildinfo=self._os_build_info2, system_libs_static=self._os_build_info2.shlibs_bases, system_libs_shared=[])
+        output = self.conan(["create", "lib", "lib/version@user/channel", "-o", "lib:shared=True", "-o", "dep:shared={}".format(dep_shared)])
+        self.assertIn("[MISSING SYSTEM LIBS (KB-H043)] OK", output)
+        for lib in self._os_build_info.shlibs_bases:
+            library = os.path.join(".", self._shlibdir, "liblib.{}".format(self._shlext))
+            self.assertNotIn("[MISSING SYSTEM LIBS (KB-H043)] Library '{library}' links to system library '{syslib}' but it is not in cpp_info.system_libs.".format(library=library, shlext=self._shlext, syslib=lib), output)
+        for lib in self._os_build_info2.shlibs_bases:
+            library = os.path.join(".", self._shlibdir, "liblib.{}".format(self._shlext))
+            self.assertNotIn("[MISSING SYSTEM LIBS (KB-H043)] Library '{library}' links to system library '{syslib}' but it is not in cpp_info.system_libs.".format(library=library, shlext=self._shlext, syslib=lib), output)
+
+    @unittest.skipUnless(not tools.is_apple_os(tools.detected_os()), "Macos is not supported")
+    @parameterized.expand([
+        ("shared_dependency", True),
+        ("static_dependency", False),
+    ])
+    def test_dep_system_lib_missing(self, name, dep_shared):
+        self._write_files(subdir="dep", name="dep", osbuildinfo=self._os_build_info, system_libs_static=self._os_build_info.shlibs_bases, system_libs_shared=[])
+        self.conan(["create", "dep", "dep/version@user/channel", "-o", "dep:shared={}".format(dep_shared)])
+        self._write_files(subdir="lib", name="lib", requires=("dep/version@user/channel", ), osbuildinfo=self._os_build_info2, system_libs_static=[], system_libs_shared=[])
+        output = self.conan(["create", "lib", "lib/version@user/channel", "-o", "lib:shared=True", "-o", "dep:shared={}".format(dep_shared)])
+        self.assertIn("[MISSING SYSTEM LIBS (KB-H043)] OK", output)
+        for lib in self._os_build_info.shlibs_bases:
+            library = os.path.join(".", self._shlibdir, "liblib.{}".format(self._shlext))
+            self.assertNotIn("[MISSING SYSTEM LIBS (KB-H043)] Library '{library}' links to system library '{syslib}' but it is not in cpp_info.system_libs.".format(library=library, shlext=self._shlext, syslib=lib), output)
+        for lib in self._os_build_info2.shlibs_bases:
+            library = os.path.join(".", self._shlibdir, "liblib.{}".format(self._shlext))
+            self.assertIn("[MISSING SYSTEM LIBS (KB-H043)] Library '{library}' links to system library '{syslib}' but it is not in cpp_info.system_libs.".format(library=library, shlext=self._shlext, syslib=lib), output)

--- a/tests/test_hooks/conan-center/test_missing_system_libs.py
+++ b/tests/test_hooks/conan-center/test_missing_system_libs.py
@@ -138,8 +138,8 @@ class ConanMissingSystemLibs(ConanClientTestCase):
     @property
     def _attribute(self):
         return {
-            "Windows": "system_lib",
-            "Linux": "system_lib",
+            "Windows": "system_libs",
+            "Linux": "system_libs",
             "Macos": "frameworks",
         }[tools.detected_os()]
 

--- a/tests/test_hooks/conan-center/test_missing_system_libs.py
+++ b/tests/test_hooks/conan-center/test_missing_system_libs.py
@@ -268,6 +268,6 @@ class ConanMissingSystemLibs(ConanClientTestCase):
         for lib in self._os_build_info2.shlibs_bases:
             library = os.path.join(".", self._shlibdir, "{}lib.{}".format(self._prefix, self._shlext))
             self.assertIn("[MISSING SYSTEM LIBS (KB-H043)] Library '{library}' links to system "
-                          "library '{syslib}' but it is not in cpp_info.{attribute}}.".
+                          "library '{syslib}' but it is not in cpp_info.{attribute}.".
                           format(library=library, shlext=self._shlext, syslib=lib,
                                  attribute=self._attribute), output)

--- a/tests/test_hooks/conan-center/test_missing_system_libs.py
+++ b/tests/test_hooks/conan-center/test_missing_system_libs.py
@@ -28,7 +28,6 @@ class ConanMissingSystemLibs(ConanClientTestCase):
         endif()
         
         add_library({name} simplelib.c)
-        set_property(TARGET {name} PROPERTY PREFIX lib)
         target_link_libraries({name} ${{LINK_TO}} ${{CONAN_LIBS}})
         include(GNUInstallDirs)
         install(TARGETS {name}
@@ -115,6 +114,14 @@ class ConanMissingSystemLibs(ConanClientTestCase):
         }[tools.detected_os()]
 
     @property
+    def _prefix(self):
+        return {
+            "Windows": "",
+            "Linux": "lib",
+            # "Macos": "lib",
+        }[tools.detected_os()]
+
+    @property
     def _shlext(self):
         return {
             "Windows": "dll",
@@ -148,7 +155,7 @@ class ConanMissingSystemLibs(ConanClientTestCase):
         output = self.conan(["create", ".", "name/version@user/channel", "-o", "name:shared=True"])
         self.assertIn("[MISSING SYSTEM LIBS (KB-H043)] OK", output)
         for lib in self._os_build_info.shlibs_bases:
-            library = os.path.join(".", self._shlibdir, "libsimplelib.{}".format(self._shlext))
+            library = os.path.join(".", self._shlibdir, "{}simplelib.{}".format(self._prefix, self._shlext))
             self.assertNotIn("[MISSING SYSTEM LIBS (KB-H043)] Library '{library}' links to system library '{syslib}' but it is not in cpp_info.system_libs.".format(library=library, shlext=self._shlext, syslib=lib), output)
 
     @unittest.skipUnless(not tools.is_apple_os(tools.detected_os()), "Macos is not supported")
@@ -157,7 +164,7 @@ class ConanMissingSystemLibs(ConanClientTestCase):
         output = self.conan(["create", ".", "name/version@user/channel", "-o", "name:shared=True"])
         self.assertIn("[MISSING SYSTEM LIBS (KB-H043)] OK", output)
         for lib in self._os_build_info.shlibs_bases:
-            library = os.path.join(".", self._shlibdir, "libsimplelib.{}".format(self._shlext))
+            library = os.path.join(".", self._shlibdir, "{}simplelib.{}".format(self._prefix, self._shlext))
             self.assertNotIn("[MISSING SYSTEM LIBS (KB-H043)] Library '{library}' links to system library '{syslib}' but it is not in cpp_info.system_libs.".format(library=library, shlext=self._shlext, syslib=lib), output)
 
     @unittest.skipUnless(not tools.is_apple_os(tools.detected_os()), "Macos is not supported")
@@ -165,7 +172,7 @@ class ConanMissingSystemLibs(ConanClientTestCase):
         self._write_files(osbuildinfo=self._os_build_info, system_libs_static=[], system_libs_shared=[])
         output  = self.conan(["create", ".", "name/version@user/channel", "-o", "name:shared=True"])
         for lib in self._os_build_info.shlibs_bases:
-            library = os.path.join(".", self._shlibdir, "libsimplelib.{}".format(self._shlext))
+            library = os.path.join(".", self._shlibdir, "{}simplelib.{}".format(self._prefix, self._shlext))
             self.assertIn("[MISSING SYSTEM LIBS (KB-H043)] Library '{library}' links to system library '{syslib}' but it is not in cpp_info.system_libs.".format(library=library, shlext=self._shlext, syslib=lib), output)
 
     @parameterized.expand([
@@ -180,10 +187,10 @@ class ConanMissingSystemLibs(ConanClientTestCase):
         output = self.conan(["create", "lib", "lib/version@user/channel", "-o", "lib:shared=True", "-o", "dep:shared={}".format(dep_shared)])
         self.assertIn("[MISSING SYSTEM LIBS (KB-H043)] OK", output)
         for lib in self._os_build_info.shlibs_bases:
-            library = os.path.join(".", self._shlibdir, "liblib.{}".format(self._shlext))
+            library = os.path.join(".", self._shlibdir, "{}lib.{}".format(self._prefix, self._shlext))
             self.assertNotIn("[MISSING SYSTEM LIBS (KB-H043)] Library '{library}' links to system library '{syslib}' but it is not in cpp_info.system_libs.".format(library=library, shlext=self._shlext, syslib=lib), output)
         for lib in self._os_build_info2.shlibs_bases:
-            library = os.path.join(".", self._shlibdir, "liblib.{}".format(self._shlext))
+            library = os.path.join(".", self._shlibdir, "{}lib.{}".format(self._prefix, self._shlext))
             self.assertNotIn("[MISSING SYSTEM LIBS (KB-H043)] Library '{library}' links to system library '{syslib}' but it is not in cpp_info.system_libs.".format(library=library, shlext=self._shlext, syslib=lib), output)
 
     @parameterized.expand([
@@ -198,8 +205,8 @@ class ConanMissingSystemLibs(ConanClientTestCase):
         output = self.conan(["create", "lib", "lib/version@user/channel", "-o", "lib:shared=True", "-o", "dep:shared={}".format(dep_shared)])
         self.assertIn("[MISSING SYSTEM LIBS (KB-H043)] OK", output)
         for lib in self._os_build_info.shlibs_bases:
-            library = os.path.join(".", self._shlibdir, "liblib.{}".format(self._shlext))
+            library = os.path.join(".", self._shlibdir, "{}lib.{}".format(self._prefix, self._shlext))
             self.assertNotIn("[MISSING SYSTEM LIBS (KB-H043)] Library '{library}' links to system library '{syslib}' but it is not in cpp_info.system_libs.".format(library=library, shlext=self._shlext, syslib=lib), output)
         for lib in self._os_build_info2.shlibs_bases:
-            library = os.path.join(".", self._shlibdir, "liblib.{}".format(self._shlext))
+            library = os.path.join(".", self._shlibdir, "{}lib.{}".format(self._prefix, self._shlext))
             self.assertIn("[MISSING SYSTEM LIBS (KB-H043)] Library '{library}' links to system library '{syslib}' but it is not in cpp_info.system_libs.".format(library=library, shlext=self._shlext, syslib=lib), output)

--- a/tests/test_hooks/conan-center/test_missing_system_libs.py
+++ b/tests/test_hooks/conan-center/test_missing_system_libs.py
@@ -108,7 +108,7 @@ class ConanMissingSystemLibs(ConanClientTestCase):
     @property
     def _os_build_info2(self):
         return {
-            "Linux": self.OSBuildInfo(["time.h"], ["librt.so"], ["rt"], "clock_settime(CLOCK_REALTIME, 0)"),
+            "Linux": self.OSBuildInfo(["mqueue.h"], ["librt.so"], ["rt"], "mq_open(0, 0)"),
             "Windows": self.OSBuildInfo(["shlwapi.h"], ["shlwapi.lib"], ["shlwapi"], "PathIsDirectory(\"C:\\Windows\")"),
             # "Macos": self.OSBuildInfo([], ["m"], "(int)tan(42.)"),
         }[tools.detected_os()]
@@ -170,7 +170,7 @@ class ConanMissingSystemLibs(ConanClientTestCase):
     @unittest.skipUnless(not tools.is_apple_os(tools.detected_os()), "Macos is not supported")
     def test_system_lib_missing(self):
         self._write_files(osbuildinfo=self._os_build_info, system_libs_static=[], system_libs_shared=[])
-        output  = self.conan(["create", ".", "name/version@user/channel", "-o", "name:shared=True"])
+        output = self.conan(["create", ".", "name/version@user/channel", "-o", "name:shared=True"])
         for lib in self._os_build_info.shlibs_bases:
             library = os.path.join(".", self._shlibdir, "{}simplelib.{}".format(self._prefix, self._shlext))
             self.assertIn("[MISSING SYSTEM LIBS (KB-H043)] Library '{library}' links to system library '{syslib}' but it is not in cpp_info.system_libs.".format(library=library, shlext=self._shlext, syslib=lib), output)

--- a/tests/test_hooks/conan-center/test_missing_system_libs.py
+++ b/tests/test_hooks/conan-center/test_missing_system_libs.py
@@ -102,7 +102,7 @@ class ConanMissingSystemLibs(ConanClientTestCase):
     def _os_build_info(self):
         return {
             "Linux": self.OSBuildInfo(["dlfcn.h"], ["libdl.so"], ["dl"], [], "dlclose((void*)0)"),
-            "Windows": self.OSBuildInfo(["winsock.h"], ["ws2_32.lib"], ["ws2_32"], [], "ntohs(0x4200)"),
+            "Windows": self.OSBuildInfo(["winsock2.h"], ["ws2_32.lib"], ["ws2_32"], [], "WSAStartup(0, 0)"),
             "Macos": self.OSBuildInfo(["CoreServices/CoreServices.h"], ["CoreServices"], [],
                                       ["CoreServices"],
                                       "FSEventStreamCopyDescription(0)"),

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ setenv =
     coverage: COVERAGE_FILE={toxinidir}/.coverage
     coverage: PYTESTDJANGO_COVERAGE_SRC={toxinidir}/
 
-passenv = PYTEST_ADDOPTS USE_UNSUPPORTED_CONAN_WITH_PYTHON_2 USERNAME
+passenv = PYTEST_ADDOPTS USE_UNSUPPORTED_CONAN_WITH_PYTHON_2 USERNAME ProgramFiles(x86) ProgramFiles
 
 commands =
     python --version


### PR DESCRIPTION
Test whether a recipe has all system libraries listed in `cpp_info.system_libs`.
This heuristic only run on Linux and Windows and can only be done for shared libraries.

WIKI:

**#KB-H041: "MISSING SYSTEM LIBS"**

A shared library links to some system libraries which are not set by `cpp_info.system_libs` in `package_info`.
This test can only be run on shared libraries.