### PR TITLE
[conan-center] Versions in conandata should be strings

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -331,6 +331,11 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
                           "conandata.yml" % (entries, allowed_first_level))
 
             for entry in conandata_yml:
+
+                versions = conandata_yml[entry].keys()
+                if any([not isinstance(it, str) for it in versions]):
+                    out.error("Versions in conandata.yml should be strings. Add quotes around the numbers")
+
                 if version not in conandata_yml[entry]:
                     continue
                 for element in conandata_yml[entry][version]:

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -332,9 +332,10 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
 
             for entry in conandata_yml:
 
-                versions = conandata_yml[entry].keys()
-                if any([not isinstance(it, str) for it in versions]):
-                    out.error("Versions in conandata.yml should be strings. Add quotes around the numbers")
+                if entry in ['sources', 'patches']:
+                    versions = conandata_yml[entry].keys()
+                    if any([not isinstance(it, str) for it in versions]):
+                        out.error("Versions in conandata.yml should be strings. Add quotes around the numbers")
 
                 if version not in conandata_yml[entry]:
                     continue

--- a/tests/test_hooks/conan-center/test_conandata.py
+++ b/tests/test_hooks/conan-center/test_conandata.py
@@ -186,6 +186,18 @@ class ConanData(ConanClientTestCase):
             if version == "1.71.0":
                 self.assertEqual(expected_conandata_1710, conandata)
 
+    def test_versions_as_string(self):
+        tools.save('conanfile.py', content=self.conanfile)
+        conandata = textwrap.dedent("""
+            sources:
+              1.73:
+                url: "url1.69.0"
+        """)
+
+        tools.save('conandata.yml', content=conandata)
+        output = self.conan(['export', '.', 'name/1.70.0@jgsogo/test'])
+        self.assertIn("ERROR: [CONANDATA.YML FORMAT (KB-H030)]", output)
+
     def test_wrong_conandata_format(self):
         tools.save('conanfile.py', content=self.conanfile)
         conandata_sources = textwrap.dedent("""
@@ -215,7 +227,6 @@ class ConanData(ConanClientTestCase):
             """)
         for conandata in [conandata_random, conandata_sources, conandata_patches,
                           conandata_patches_specific]:
-            print(conandata)
             tools.save('conandata.yml', content=conandata)
             output = self.conan(['export', '.', 'name/1.70.0@jgsogo/test'])
             self.assertIn("ERROR: [CONANDATA.YML FORMAT (KB-H030)]", output)

--- a/tests/test_hooks/conan-center/test_conandata.py
+++ b/tests/test_hooks/conan-center/test_conandata.py
@@ -196,7 +196,7 @@ class ConanData(ConanClientTestCase):
 
         tools.save('conandata.yml', content=conandata)
         output = self.conan(['export', '.', 'name/1.70.0@jgsogo/test'])
-        self.assertIn("ERROR: [CONANDATA.YML FORMAT (KB-H030)]", output)
+        self.assertIn("ERROR: [CONANDATA.YML FORMAT (KB-H030)] Versions in conandata.yml should be strings", output)
 
     def test_wrong_conandata_format(self):
         tools.save('conanfile.py', content=self.conanfile)


### PR DESCRIPTION
Add a check to conan-center hook: versions in conandata should be strings. Comes from https://github.com/conan-io/conan/issues/6697 I thought we were already checking it... have I missed something?