### PR TITLE
#175 Do not allow requires.add (KB-H044)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,24 +33,24 @@ jobs:
       env: TOXENV=py38-conancurrent
       dist: xenial
 
-    - stage: Linux - Conan 1.21
+    - stage: Linux - Conan 1.23
       name: Python 3.5
       python: 3.5
-      env: TOXENV=py35-conan121
+      env: TOXENV=py35-conan123
       dist: xenial
     - name: Python 3.8
       python: 3.8
-      env: TOXENV=py38-conan121
+      env: TOXENV=py38-conan123
       dist: xenial
 
-    - stage: Linux - Conan 1.20
+    - stage: Linux - Conan 1.22
       name: Python 3.5
       python: 3.5
-      env: TOXENV=py35-conan120
+      env: TOXENV=py35-conan122
       dist: xenial
     - name: Python 3.8
       python: 3.8
-      env: TOXENV=py38-conan120
+      env: TOXENV=py38-conan122
       dist: xenial
 
     # Macos is slow, only if everything has passed

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,13 +20,13 @@ environment:
         - PYVER: py38
           TOXENV: py38-conancurrent
 
-        # Conan 1.21.x
+        # Conan 1.23.x
         - PYVER: py38
-          TOXENV: py38-conan121
+          TOXENV: py38-conan123
 
-        # Conan 1.20.x
+        # Conan 1.22.x
         - PYVER: py38
-          TOXENV: py38-conan120
+          TOXENV: py38-conan122
 
 install:
   - set PATH=%PATH%;%PYTHON%/Scripts/

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -43,6 +43,7 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H034": "TEST PACKAGE - NO IMPORTS()",
              "KB-H037": "NO AUTHOR",
              "KB-H040": "NO TARGET NAME",
+             "KB-H044": "NO REQUIRES.ADD()",
             }
 
 
@@ -383,6 +384,14 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
                 out.error("CCI uses the name of the package for {0} generator. "
                           "Conanfile should not contain 'self.cpp_info.names['{0}']'. "
                           " Use 'cmake_find_package' and 'cmake_find_package_multi' instead.".format(generator))
+
+    @run_test("KB-H044", output)
+    def test(out):
+        for forbidden in ["self.requires.add", "self.build_requires.add"]:
+            if forbidden in conanfile_content:
+                out.error("The method '{}()' is not allowed. Use '{}()' instead."
+                          .format(forbidden, forbidden.replace(".add", "")))
+
 
 @raise_if_error_output
 def post_export(output, conanfile, conanfile_path, reference, **kwargs):

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,14 @@
 [tox]
 skipsdist=True
 envlist =
-    py{27,35,37,38}-conan{dev,latest,120,121}
+    py{27,35,37,38}-conan{dev,latest,122,123}
 
 [testenv]
 deps =
     conandev: https://github.com/conan-io/conan/archive/develop.tar.gz
     conancurrent: conan
-    conan121: conan>=1.21,<1.22
-    conan120: conan>=1.20,<1.21
+    conan123: conan>=1.23,<1.24
+    conan122: conan>=1.22,<1.23
     coverage: coverage-enable-subprocess
     -r {toxinidir}/tests/requirements_test.txt
 


### PR DESCRIPTION
closes #175 

Wiki:

#### **<a name="KB-H044">#KB-H044</a>: "NO REQUIRES.ADD()"**

Both `self.requires.add()` and `self.build_requires.add()` have been deprecated in favor of `self.requires()` and `self.build_requires()` which were introduced on Conan 1.x. Both `add()` were introduced during Conan 0.x and since Conan 1.23 they no longer follow the original behavior.