### PR TITLE
Check option for deletion

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -43,6 +43,7 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H034": "TEST PACKAGE - NO IMPORTS()",
              "KB-H037": "NO AUTHOR",
              "KB-H040": "NO TARGET NAME",
+             "KB-H045": "DELETE OPTIONS",
             }
 
 
@@ -383,6 +384,12 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
                 out.error("CCI uses the name of the package for {0} generator. "
                           "Conanfile should not contain 'self.cpp_info.names['{0}']'. "
                           " Use 'cmake_find_package' and 'cmake_find_package_multi' instead.".format(generator))
+
+    @run_test("KB-H045", output)
+    def test(out):
+        if "self.options.remove" in conanfile_content:
+            out.error("Found 'self.options.remove'. Replace it by 'del self.options.<opt>'.")
+
 
 @raise_if_error_output
 def post_export(output, conanfile, conanfile_path, reference, **kwargs):

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -597,3 +597,21 @@ class ConanCenterTests(ConanClientTestCase):
             tools.save('conanfile.py', content=conanfile.replace("{}", it))
             output = self.conan(['create', '.', 'name/version@user/test'])
             self.assertIn("[NO TARGET NAME (KB-H040)] OK", output)
+
+    def test_delete_option(self):
+        conanfile = textwrap.dedent("""\
+        from conans import ConanFile
+        class AConan(ConanFile):
+            options = {"foo": [True, False]}
+
+            def config_options(self):
+                {}
+        """)
+        tools.save('conanfile.py', content=conanfile.replace("{}", "del self.options.foo"))
+        output = self.conan(['create', '.', 'name/version@user/test'])
+        self.assertIn("[DELETE OPTIONS (KB-H045)] OK", output)
+
+        tools.save('conanfile.py', content=conanfile.replace("{}", 'self.options.remove("foo")'))
+        output = self.conan(['create', '.', 'name/version@user/test'])
+        self.assertIn("ERROR: [DELETE OPTIONS (KB-H045)] Found 'self.options.remove'."
+                      " Replace it by 'del self.options.<opt>'.", output)


### PR DESCRIPTION
closes #179

/cc @SSE4 @danimtb 

#### **<a name="KB-H045">#KB-H045</a>: "DELETE OPTIONS"**

The method `self.options.remove` was introduced in Conan 0.x, however Conan 1.x brings a more pythonic way for removing options from your recipe.