### PR TITLE
[conan-center] Whitelist pybind11 for KB-H016

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -535,7 +535,7 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
 
     @run_test("KB-H016", output)
     def test(out):
-        if conanfile.name in ["cmake", "msys2", "strawberryperl"]:
+        if conanfile.name in ["cmake", "msys2", "strawberryperl", "pybind11"]:
             return
         bad_files = _get_files_following_patterns(conanfile.package_folder, ["Find*.cmake",
                                                                              "*Config.cmake",


### PR DESCRIPTION
I'd like to unblock https://github.com/conan-io/conan-center-index/pull/464 and I am a bit hesitant about the changes in #145. In order to move forward, I have whitelisted this package in this check.

We can revert this once #145 is in place and works with the pybind11 use case.