### PR TITLE
KB-H017: Allow backslashes in builddirs (as is usual the case on Windows)

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -647,7 +647,7 @@ def post_package_info(output, conanfile, reference, **kwargs):
         if conanfile.name in ["cmake", "msys2", "strawberryperl"]:
             return
         bad_files = _get_files_following_patterns(conanfile.package_folder, ["*.cmake"])
-        build_dirs = conanfile.cpp_info.builddirs
+        build_dirs = [bd.replace("\\", "/") for bd in conanfile.cpp_info.builddirs]
         files_missplaced = []
 
         for filename in bad_files:

--- a/tests/test_hooks/conan-center/test_cmake_bad_files.py
+++ b/tests/test_hooks/conan-center/test_cmake_bad_files.py
@@ -90,6 +90,6 @@ class ConanCMakeBadFiles(ConanClientTestCase):
         output = self.conan(['create', '.', 'name/version@user/channel'])
         self.assertNotIn("ERROR: [CMAKE FILE NOT IN BUILD FOLDERS (KB-H019)]", output)
 
-        tools.save('conanfile.py', content=self.conan_file_info.format("""os.path.join("lib", "cmake", "script.cmake")""", ["lib\\cmake"]))
+        tools.save('conanfile.py', content=self.conan_file_info.format('os.path.join("lib", "cmake", "script.cmake")', ["lib\\cmake"]))
         output = self.conan(['create', '.', 'name/version@user/channel'])
         self.assertNotIn("ERROR: [CMAKE FILE NOT IN BUILD FOLDERS (KB-H019)]", output)

--- a/tests/test_hooks/conan-center/test_cmake_bad_files.py
+++ b/tests/test_hooks/conan-center/test_cmake_bad_files.py
@@ -86,11 +86,10 @@ class ConanCMakeBadFiles(ConanClientTestCase):
         self.assertNotIn("ERROR: [CMAKE FILE NOT IN BUILD FOLDERS (KB-H019)]", output)
 
     def test_good_files(self):
-        tools.save('conanfile.py', content=self.conan_file_info.format("""os.path.join("lib", "cmake", "script.cmake")""", ["lib/cmake"]))
+        tools.save('conanfile.py', content=self.conan_file_info.format('os.path.join("lib", "cmake", "script.cmake")', ["lib/cmake"]))
         output = self.conan(['create', '.', 'name/version@user/channel'])
         self.assertNotIn("ERROR: [CMAKE FILE NOT IN BUILD FOLDERS (KB-H019)]", output)
 
         tools.save('conanfile.py', content=self.conan_file_info.format("""os.path.join("lib", "cmake", "script.cmake")""", ["lib\\cmake"]))
         output = self.conan(['create', '.', 'name/version@user/channel'])
         self.assertNotIn("ERROR: [CMAKE FILE NOT IN BUILD FOLDERS (KB-H019)]", output)
-

--- a/tests/test_hooks/conan-center/test_cmake_bad_files.py
+++ b/tests/test_hooks/conan-center/test_cmake_bad_files.py
@@ -20,6 +20,19 @@ class ConanCMakeBadFiles(ConanClientTestCase):
                         tools.save(os.path.join(self.package_folder, "{}", "{}"), "foo")
                 """)
 
+    conan_file_info = textwrap.dedent("""\
+                import os
+                from conans import ConanFile, tools
+
+                class AConan(ConanFile):
+
+                    def package(self):
+                        tools.save(os.path.join(self.package_folder, {}), "foo")
+
+                    def package_info(self):
+                        self.cpp_info.builddirs = {!r}
+                """)
+
     def _get_environ(self, **kwargs):
         kwargs = super(ConanCMakeBadFiles, self)._get_environ(**kwargs)
         kwargs.update({'CONAN_HOOKS': os.path.join(os.path.dirname(__file__), '..', '..', '..',
@@ -71,3 +84,13 @@ class ConanCMakeBadFiles(ConanClientTestCase):
         tools.save('conanfile.py', content=conanfile2.format("some_build_dir/subdir"))
         output = self.conan(['create', '.', 'name/version@user/channel'])
         self.assertNotIn("ERROR: [CMAKE FILE NOT IN BUILD FOLDERS (KB-H019)]", output)
+
+    def test_good_files(self):
+        tools.save('conanfile.py', content=self.conan_file_info.format("""os.path.join("lib", "cmake", "script.cmake")""", ["lib/cmake"]))
+        output = self.conan(['create', '.', 'name/version@user/channel'])
+        self.assertNotIn("ERROR: [CMAKE FILE NOT IN BUILD FOLDERS (KB-H019)]", output)
+
+        tools.save('conanfile.py', content=self.conan_file_info.format("""os.path.join("lib", "cmake", "script.cmake")""", ["lib\\cmake"]))
+        output = self.conan(['create', '.', 'name/version@user/channel'])
+        self.assertNotIn("ERROR: [CMAKE FILE NOT IN BUILD FOLDERS (KB-H019)]", output)
+

--- a/tests/test_hooks/test_members_typo_checker.py
+++ b/tests/test_hooks/test_members_typo_checker.py
@@ -25,7 +25,7 @@ class MembersTypoCheckerTests(ConanClientTestCase):
             name = "name"
             version = "version"
 
-            export_sources = "OH_NO"
+            exports_sourcess = "OH_NO"
 
             require = "Hello/0.1@oh_no/stable"
 
@@ -51,7 +51,7 @@ class MembersTypoCheckerTests(ConanClientTestCase):
         tools.save('conanfile.py', content=self.conanfile_with_typos)
         output = self.conan(['export', '.', 'name/version@jgsogo/test'])
         self.assertIn(
-            "pre_export(): WARN: The 'export_sources' member looks like a typo. Similar to:", output)
+            "pre_export(): WARN: The 'exports_sourcess' member looks like a typo. Similar to:", output)
         self.assertIn(
             "pre_export(): WARN:     exports_sources", output)
         self.assertIn(


### PR DESCRIPTION
When a builddir contains a backslash, it was compared against a path with forward slashes.
This pr converts the builddirs to forward slashes (for use in the hook).

This fixes false positives such as https://github.com/conan-io/conan-center-index/pull/1753#issuecomment-634944737
