### PR TITLE
conan-center: add meson to exception list of KB-H019 (it contains a cmake script)

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -668,7 +668,7 @@ def post_package_info(output, conanfile, reference, **kwargs):
 
     @run_test("KB-H019", output)
     def test(out):
-        if conanfile.name in ["cmake", "msys2", "strawberryperl"]:
+        if conanfile.name in ["cmake", "meson", "msys2", "strawberryperl"]:
             return
         bad_files = _get_files_following_patterns(conanfile.package_folder, ["*.cmake"])
         build_dirs = [bd.replace("\\", "/") for bd in conanfile.cpp_info.builddirs]


### PR DESCRIPTION
This pr adds meson to the exception list of KB-H019.

This *should* fix the CI failures I'm having with pkgconf at https://github.com/conan-io/conan-center-index/pull/1013#issuecomment-653746667

I've just checked meson 0.54.3 and it contains the following cmake script:
- **bin/mesonbuild/cmake/data/preload.cmake**

I've copied the contents of the script here below.
I think an exception is required instead of adding it to `cpp_info.builddirs`.

<details>

<summary>contents of meson's preload.cmake</summary>

```cmake
if(MESON_PS_LOADED)
  return()
endif()

set(MESON_PS_LOADED ON)

# Dummy macros that have a special meaning in the meson code
macro(meson_ps_execute_delayed_calls)
endmacro()

macro(meson_ps_reload_vars)
endmacro()

# Helper macro to inspect the current CMake state
macro(meson_ps_inspect_vars)
  set(MESON_PS_CMAKE_CURRENT_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
  set(MESON_PS_CMAKE_CURRENT_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
  meson_ps_execute_delayed_calls()
endmacro()


# Override some system functions with custom code and forward the args
# to the original function
macro(add_custom_command)
  meson_ps_inspect_vars()
  _add_custom_command(${ARGV})
endmacro()

macro(add_custom_target)
  meson_ps_inspect_vars()
  _add_custom_target(${ARGV})
endmacro()

macro(set_property)
  meson_ps_inspect_vars()
  _set_property(${ARGV})
endmacro()

function(set_source_files_properties)
  set(FILES)
  set(I 0)
  set(PROPERTIES OFF)

  while(I LESS ARGC)
    if(NOT PROPERTIES)
      if("${ARGV${I}}" STREQUAL "PROPERTIES")
        set(PROPERTIES ON)
      else()
        list(APPEND FILES "${ARGV${I}}")
      endif()

      math(EXPR I "${I} + 1")
    else()
      set(ID_IDX ${I})
      math(EXPR PROP_IDX "${ID_IDX} + 1")

      set(ID   "${ARGV${ID_IDX}}")
      set(PROP "${ARGV${PROP_IDX}}")

      set_property(SOURCE ${FILES} PROPERTY "${ID}" "${PROP}")
      math(EXPR I "${I} + 2")
    endif()
  endwhile()
endfunction()

set(MESON_PS_DELAYED_CALLS add_custom_command;add_custom_target;set_property)
meson_ps_reload_vars()
```

</details>

/cc @uilianries @ericLemanissier 