### PR TITLE
fix KB-H032 SYSTEM REQUIREMENTS

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -296,7 +296,7 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
 
     @run_test("KB-H032", output)
     def test(out):
-        if conanfile.name in ["libusb"]:
+        if conanfile.name in ["libusb"] or conanfile.version == "system":
             out.info("'{}' is part of the allowlist.".format(conanfile.name))
             return
         if "def system_requirements" in conanfile_content and \

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -302,7 +302,7 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
         if "def system_requirements" in conanfile_content and \
            "SystemPackageTool" in conanfile_content:
             import re
-            match = re.search(r'(\S+)\s?=\s?SystemPackageTool', conanfile_content)
+            match = re.search(r'(\S+)\s?=\s?(tools.)?SystemPackageTool', conanfile_content)
             if ("SystemPackageTool().install" in conanfile_content) or \
                (match and "{}.install".format(match.group(1)) in conanfile_content):
                 out.error("The method 'SystemPackageTool.install' is not allowed in the recipe.")


### PR DESCRIPTION
it did not catch the following pattern, just because the presence of "tools.":
installer = tools.SystemPackageTool()
installer.install('libcap-dev')