### PR TITLE
Check for invalid symlinks

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -49,6 +49,7 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H046": "CMAKE VERBOSE MAKEFILE",
              "KB-H047": "NO ASCII CHARACTERS",
              "KB-H048": "CMAKE VERSION REQUIRED",
+             "KB-H049": "INVALID SYMLINKS",
             }
 
 
@@ -681,6 +682,16 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
         if bad_files:
             out.error("The conan-center repository doesn't allow Microsoft Visual Studio runtime files.")
             out.error("Found files:\n{}".format("\n".join(bad_files)))
+
+    @run_test("KB-H049", output)
+    def test(out):
+        """ Check that all symlinks are contained inside the package """
+        try:
+            tools.fix_symlinks(conanfile, raise_if_error=True)
+        except ConanException:
+            out.error("There are symlinks in the package pointing outside the package_folder."
+                      " You can use 'tools.fix_symlinks(self)' to fix some of these symlinks.")
+
 
 def post_package_info(output, conanfile, reference, **kwargs):
 

--- a/tests/test_hooks/conan-center/test_invalid_symlinks.py
+++ b/tests/test_hooks/conan-center/test_invalid_symlinks.py
@@ -1,0 +1,33 @@
+import os
+import textwrap
+
+from conans import tools
+
+from tests.utils.test_cases.conan_client import ConanClientTestCase
+
+
+class InvalidSymlinksTestCase(ConanClientTestCase):
+    conanfile = textwrap.dedent("""\
+        import os
+        from conans import ConanFile, tools
+
+        class AConan(ConanFile):
+
+            def build(self):
+                tools.save(os.path.join(self.build_folder, "build.txt"), "contents")
+
+            def package(self):
+                os.symlink(os.path.join(self.build_folder, "build.txt"),
+                           os.path.join(self.package_folder, "outside_symlink.txt"))
+        """)
+
+    def _get_environ(self, **kwargs):
+        kwargs = super(NoPDBsTests, self)._get_environ(**kwargs)
+        kwargs.update({'CONAN_HOOKS': os.path.join(os.path.dirname(__file__), '..', '..', '..',
+                                                   'hooks', 'conan-center')})
+        return kwargs
+
+    def test_symlink_invalid(self):
+        tools.save('conanfile.py', content=self.conanfile)
+        output = self.conan(['create', '.', 'name/version@user/channel'])
+        self.assertIn("ERROR: [INVALID SYMLINKS (KB-H049)]", output)


### PR DESCRIPTION
Run [tool `fix_symlinks`](https://docs.conan.io/en/latest/reference/tools.html?highlight=fix_symlinks#tools-fix-symlinks) and fail if the tool reported invalid symlinks.


Closes https://github.com/conan-io/hooks/issues/202