### PR TITLE
[conan-center] KB-H049: CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS requires CMake 3.4

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -495,6 +495,7 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
                         out.error("The CMake definition {} requires CMake 3.4 at least. Update "
                                 "CMakeLists.txt to 'cmake_minimum_required(VERSION 3.4)'."
                                 .format(cmake_def))
+                        break
 
 
 @raise_if_error_output

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -49,6 +49,7 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H046": "CMAKE VERBOSE MAKEFILE",
              "KB-H047": "NO ASCII CHARACTERS",
              "KB-H048": "CMAKE VERSION REQUIRED",
+             "KB-H049": "CMAKE EXPORT ALL SYMBOLS",
             }
 
 
@@ -479,6 +480,17 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
                "cxx_standard" in cmake_content.lower():
                 out.error("The CMake definition CXX_STANDARD requires CMake 3.1 at least."
                           " Update to 'cmake_minimum_required(VERSION 3.1)'.")
+
+    @run_test("KB-H049", output)
+    def test(out):
+        dir_path = os.path.dirname(conanfile_path)
+        cmake_path = os.path.join(dir_path, "CMakeLists.txt")
+        if os.path.isfile(cmake_path):
+            cmake_content = tools.load(cmake_path)
+            match = re.search(r"cmake_minimum_required\s?\(VERSION (\d?\.?\d?\.?\d+)\)", cmake_content, re.I)
+            if match and tools.Version(match.group(1)) < "3.4" and "WINDOWS_EXPORT_ALL_SYMBOLS" in cmake_content:
+                out.error("The CMake definition WINDOWS_EXPORT_ALL_SYMBOLS requires CMake 3.4 at least."
+                          " Update to 'cmake_minimum_required(VERSION 3.4)'.")
 
 
 @raise_if_error_output

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -489,10 +489,11 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
             cmake_content = tools.load(cmake_path)
             match = re.search(r"cmake_minimum_required\s?\(VERSION (\d?\.?\d?\.?\d+)\)",
                               cmake_content, re.I)
-            if match and tools.Version(match.group(1)) < "3.4" and \
-               "CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS" in cmake_content:
-                out.error("The CMake definition CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS requires CMake 3.4"
-                          " at least. Update to 'cmake_minimum_required(VERSION 3.4)'.")
+            if match and tools.Version(match.group(1)) < "3.4":
+                for cmake_def in ["WINDOWS_EXPORT_ALL_SYMBOLS", "CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"]:
+                    out.error("The CMake definition {} requires CMake 3.4 at least. Update "
+                              "CMakeLists.txt to 'cmake_minimum_required(VERSION 3.4)'."
+                              .format(cmake_def))
 
 
 @raise_if_error_output

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -49,7 +49,7 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H046": "CMAKE VERBOSE MAKEFILE",
              "KB-H047": "NO ASCII CHARACTERS",
              "KB-H048": "CMAKE VERSION REQUIRED",
-             "KB-H049": "CMAKE EXPORT ALL SYMBOLS",
+             "KB-H049": "CMAKE WINDOWS EXPORT ALL SYMBOLS",
             }
 
 
@@ -487,10 +487,12 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
         cmake_path = os.path.join(dir_path, "CMakeLists.txt")
         if os.path.isfile(cmake_path):
             cmake_content = tools.load(cmake_path)
-            match = re.search(r"cmake_minimum_required\s?\(VERSION (\d?\.?\d?\.?\d+)\)", cmake_content, re.I)
-            if match and tools.Version(match.group(1)) < "3.4" and "WINDOWS_EXPORT_ALL_SYMBOLS" in cmake_content:
-                out.error("The CMake definition WINDOWS_EXPORT_ALL_SYMBOLS requires CMake 3.4 at least."
-                          " Update to 'cmake_minimum_required(VERSION 3.4)'.")
+            match = re.search(r"cmake_minimum_required\s?\(VERSION (\d?\.?\d?\.?\d+)\)",
+                              cmake_content, re.I)
+            if match and tools.Version(match.group(1)) < "3.4" and \
+               "CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS" in cmake_content:
+                out.error("The CMake definition CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS requires CMake 3.4"
+                          " at least. Update to 'cmake_minimum_required(VERSION 3.4)'.")
 
 
 @raise_if_error_output

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -490,7 +490,7 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
             match = re.search(r"cmake_minimum_required\s?\(VERSION (\d?\.?\d?\.?\d+)\)",
                               cmake_content, re.I)
             if match and tools.Version(match.group(1)) < "3.4":
-                for cmake_def in ["WINDOWS_EXPORT_ALL_SYMBOLS", "CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"]:
+                for cmake_def in ["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS", "WINDOWS_EXPORT_ALL_SYMBOLS"]:
                     if cmake_def in cmake_content:
                         out.error("The CMake definition {} requires CMake 3.4 at least. Update "
                                 "CMakeLists.txt to 'cmake_minimum_required(VERSION 3.4)'."

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -491,9 +491,10 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
                               cmake_content, re.I)
             if match and tools.Version(match.group(1)) < "3.4":
                 for cmake_def in ["WINDOWS_EXPORT_ALL_SYMBOLS", "CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"]:
-                    out.error("The CMake definition {} requires CMake 3.4 at least. Update "
-                              "CMakeLists.txt to 'cmake_minimum_required(VERSION 3.4)'."
-                              .format(cmake_def))
+                    if cmake_def in cmake_content:
+                        out.error("The CMake definition {} requires CMake 3.4 at least. Update "
+                                "CMakeLists.txt to 'cmake_minimum_required(VERSION 3.4)'."
+                                .format(cmake_def))
 
 
 @raise_if_error_output

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -845,14 +845,17 @@ class ConanCenterTests(ConanClientTestCase):
         tools.save('CMakeLists.txt', content=cmake.replace("3.4", "2.8.12"))
         output = self.conan(['export', '.', 'name/version@user/test'])
         self.assertIn("ERROR: [CMAKE WINDOWS EXPORT ALL SYMBOLS (KB-H049)] The CMake definition "
-                      "CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS requires CMake 3.4 at least. Update to "
-                      "'cmake_minimum_required(VERSION 3.4)'.", output)
+                      "CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS requires CMake 3.4 at least. Update "
+                      "CMakeLists.txt to 'cmake_minimum_required(VERSION 3.4)'.", output)
 
-        tools.save('CMakeLists.txt', content=cmake.replace("3.4", "3"))
+        tools.save('CMakeLists.txt',
+                   content=cmake.replace("3.4", "3")
+                                .replace("CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS",
+                                         "WINDOWS_EXPORT_ALL_SYMBOLS"))
         output = self.conan(['export', '.', 'name/version@user/test'])
         self.assertIn("ERROR: [CMAKE WINDOWS EXPORT ALL SYMBOLS (KB-H049)] The CMake definition "
-                      "CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS requires CMake 3.4 at least. Update to "
-                      "'cmake_minimum_required(VERSION 3.4)'.", output)
+                      "WINDOWS_EXPORT_ALL_SYMBOLS requires CMake 3.4 at least. Update "
+                      "CMakeLists.txt to 'cmake_minimum_required(VERSION 3.4)'.", output)
 
         tools.save('CMakeLists.txt', content=cmake.replace("3.4", "3.17"))
         output = self.conan(['export', '.', 'name/version@user/test'])

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -840,20 +840,20 @@ class ConanCenterTests(ConanClientTestCase):
         tools.save('conanfile.py', content=conanfile)
         tools.save('CMakeLists.txt', content=cmake)
         output = self.conan(['export', '.', 'name/version@user/test'])
-        self.assertIn("[CMAKE EXPORT ALL SYMBOLS (KB-H049)] OK", output)
+        self.assertIn("[CMAKE WINDOWS EXPORT ALL SYMBOLS (KB-H049)] OK", output)
 
         tools.save('CMakeLists.txt', content=cmake.replace("3.4", "2.8.12"))
         output = self.conan(['export', '.', 'name/version@user/test'])
-        self.assertIn("ERROR: [CMAKE EXPORT ALL SYMBOLS (KB-H049)] The CMake definition "
-                      "WINDOWS_EXPORT_ALL_SYMBOLS requires CMake 3.4 at least. Update to "
+        self.assertIn("ERROR: [CMAKE WINDOWS EXPORT ALL SYMBOLS (KB-H049)] The CMake definition "
+                      "CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS requires CMake 3.4 at least. Update to "
                       "'cmake_minimum_required(VERSION 3.4)'.", output)
 
         tools.save('CMakeLists.txt', content=cmake.replace("3.4", "3"))
         output = self.conan(['export', '.', 'name/version@user/test'])
-        self.assertIn("ERROR: [CMAKE EXPORT ALL SYMBOLS (KB-H049)] The CMake definition "
-                      "WINDOWS_EXPORT_ALL_SYMBOLS requires CMake 3.4 at least. Update to "
+        self.assertIn("ERROR: [CMAKE WINDOWS EXPORT ALL SYMBOLS (KB-H049)] The CMake definition "
+                      "CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS requires CMake 3.4 at least. Update to "
                       "'cmake_minimum_required(VERSION 3.4)'.", output)
 
         tools.save('CMakeLists.txt', content=cmake.replace("3.4", "3.17"))
         output = self.conan(['export', '.', 'name/version@user/test'])
-        self.assertIn("[CMAKE EXPORT ALL SYMBOLS (KB-H049)] OK", output)
+        self.assertIn("[CMAKE WINDOWS EXPORT ALL SYMBOLS (KB-H049)] OK", output)

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -828,3 +828,32 @@ class ConanCenterTests(ConanClientTestCase):
         tools.save('test_package/CMakeLists.txt', content=cmake)
         output = self.conan(['export', '.', 'name/version@user/test'])
         self.assertIn("[CMAKE VERSION REQUIRED (KB-H048)] OK", output)
+
+
+    def test_cmake_export_all_symbols_version_required(self):
+        conanfile = self.conanfile_base.format(placeholder="exports_sources = \"CMakeLists.txt\"")
+        cmake = textwrap.dedent("""
+                cmake_minimum_required(VERSION 3.4)
+                project(test)
+                set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+                """)
+        tools.save('conanfile.py', content=conanfile)
+        tools.save('CMakeLists.txt', content=cmake)
+        output = self.conan(['export', '.', 'name/version@user/test'])
+        self.assertIn("[CMAKE EXPORT ALL SYMBOLS (KB-H049)] OK", output)
+
+        tools.save('CMakeLists.txt', content=cmake.replace("3.4", "2.8.12"))
+        output = self.conan(['export', '.', 'name/version@user/test'])
+        self.assertIn("ERROR: [CMAKE EXPORT ALL SYMBOLS (KB-H049)] The CMake definition "
+                      "WINDOWS_EXPORT_ALL_SYMBOLS requires CMake 3.4 at least. Update to "
+                      "'cmake_minimum_required(VERSION 3.4)'.", output)
+
+        tools.save('CMakeLists.txt', content=cmake.replace("3.4", "3"))
+        output = self.conan(['export', '.', 'name/version@user/test'])
+        self.assertIn("ERROR: [CMAKE EXPORT ALL SYMBOLS (KB-H049)] The CMake definition "
+                      "WINDOWS_EXPORT_ALL_SYMBOLS requires CMake 3.4 at least. Update to "
+                      "'cmake_minimum_required(VERSION 3.4)'.", output)
+
+        tools.save('CMakeLists.txt', content=cmake.replace("3.4", "3.17"))
+        output = self.conan(['export', '.', 'name/version@user/test'])
+        self.assertIn("[CMAKE EXPORT ALL SYMBOLS (KB-H049)] OK", output)


### PR DESCRIPTION
We have PRs in CCI which requires CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS, but we know, it requires CMake 3.4 at least: https://cmake.org/cmake/help/v3.4/variable/CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS.html

Docs: https://github.com/conan-io/conan-center-index/pull/2593