### PR TITLE
check default shared option value

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -509,16 +509,13 @@ def post_export(output, conanfile, conanfile_path, reference, **kwargs):
 
     @run_test("KB-H050", output)
     def test(out):
-        # TODO: Add current allowlist from CCI
-        if conanfile.name in ["glib", "paho-mqtt-c"]:
+        if conanfile.name in ["glib", "paho-mqtt-c", "tbb"]:
             out.info("'{}' is part of the allowlist, skipping.".format(conanfile.name))
             return
 
         default_options = getattr(conanfile, "default_options")
-        if default_options:
-            shared = default_options.get("shared")
-            if shared == True:
-                out.error("The option 'shared' must be 'False' by default. Update 'default_options'.")
+        if default_options and default_options.get("shared") == True:
+            out.error("The option 'shared' must be 'False' by default. Update 'default_options'.")
 
 
 @raise_if_error_output

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -297,7 +297,7 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
 
     @run_test("KB-H032", output)
     def test(out):
-        if conanfile.name in ["libusb"] or conanfile.version == "system":
+        if conanfile.name in ["libusb", "backward-cpp"] or conanfile.version == "system":
             out.info("'{}' is part of the allowlist.".format(conanfile.name))
             return
         if "def system_requirements" in conanfile_content and \
@@ -510,7 +510,7 @@ def post_export(output, conanfile, conanfile_path, reference, **kwargs):
     @run_test("KB-H050", output)
     def test(out):
         # TODO: Add current allowlist from CCI
-        if conanfile.name in []:
+        if conanfile.name in ["glib", "paho-mqtt-c"]:
             out.info("'{}' is part of the allowlist, skipping.".format(conanfile.name))
             return
 

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -49,6 +49,7 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H046": "CMAKE VERBOSE MAKEFILE",
              "KB-H047": "NO ASCII CHARACTERS",
              "KB-H048": "CMAKE VERSION REQUIRED",
+             "KB-H050": "DEFAULT SHARED OPTION VALUE",
             }
 
 
@@ -505,6 +506,19 @@ def post_export(output, conanfile, conanfile_path, reference, **kwargs):
             new_conandata_yml = yaml.safe_dump(info, default_flow_style=False)
             out.info("New conandata.yml contents: {}".format(new_conandata_yml))
             tools.save(conandata_path, new_conandata_yml)
+
+    @run_test("KB-H050", output)
+    def test(out):
+        # TODO: Add current allowlist from CCI
+        if conanfile.name in []:
+            out.info("'{}' is part of the allowlist, skipping.".format(conanfile.name))
+            return
+
+        default_options = getattr(conanfile, "default_options")
+        if default_options:
+            shared = default_options.get("shared")
+            if shared == True:
+                out.error("The option 'shared' must be 'False' by default. Update 'default_options'.")
 
 
 @raise_if_error_output

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -828,3 +828,24 @@ class ConanCenterTests(ConanClientTestCase):
         tools.save('test_package/CMakeLists.txt', content=cmake)
         output = self.conan(['export', '.', 'name/version@user/test'])
         self.assertIn("[CMAKE VERSION REQUIRED (KB-H048)] OK", output)
+
+    def test_default_option_value(self):
+        conanfile = textwrap.dedent("""\
+        from conans import ConanFile
+        class AConan(ConanFile):
+            options = {"shared": [True, False]}
+            default_options = {"shared": False}
+        """)
+
+        tools.save('conanfile.py', content=conanfile)
+        output = self.conan(['export', '.', 'name/version@user/test'])
+        self.assertIn("[DEFAULT SHARED OPTION VALUE (KB-H050)] OK", output)
+
+        tools.save('conanfile.py', content=self.conanfile_header_only)
+        output = self.conan(['export', '.', 'name/version@user/test'])
+        self.assertIn("[DEFAULT SHARED OPTION VALUE (KB-H050)] OK", output)
+
+        tools.save('conanfile.py', content=conanfile.replace("False}", "True}"))
+        output = self.conan(['export', '.', 'name/version@user/test'])
+        self.assertIn("ERROR: [DEFAULT SHARED OPTION VALUE (KB-H050)] The option 'shared' must be "
+                      "'False' by default. Update 'default_options'.", output)


### PR DESCRIPTION
Add a new check to validate options.shared when is True by default. It's a rare case, and most of time is a mistake.

closes https://github.com/conan-io/hooks/issues/217
Docs: https://github.com/conan-io/conan-center-index/pull/2615

To understand the allowlist, read the issue, there are more details there.

/cc @Croydon 