### PR TITLE
check if version is missing from config.yml

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -49,7 +49,8 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H048": "CMAKE VERSION REQUIRED",
              "KB-H049": "CMAKE WINDOWS EXPORT ALL SYMBOLS",
              "KB-H050": "DEFAULT SHARED OPTION VALUE",
-             "KB-H051": "DEFAULT OPTIONS AS DICTIONARY"
+             "KB-H051": "DEFAULT OPTIONS AS DICTIONARY",
+             "KB-H052": "CONFIG.YML HAS NEW VERSION"
              }
 
 
@@ -133,6 +134,12 @@ def run_test(kb_id, output):
             raise e
 
     return tmp
+
+
+def load_yml(path):
+    if os.path.isfile(path):
+        return yaml.safe_load(tools.load(path))
+    return None
 
 
 @raise_if_error_output
@@ -331,40 +338,38 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
                         not_allowed.append(field)
             return not_allowed
 
-        if os.path.exists(conandata_path):
-            conandata = tools.load(conandata_path)
-            conandata_yml = yaml.safe_load(conandata)
-            if not conandata_yml:
-                return
-            entries = _not_allowed_entries(list(conandata_yml.keys()), allowed_first_level)
-            if entries:
-                out.error("First level entries %s not allowed. Use only first level entries %s in "
-                          "conandata.yml" % (entries, allowed_first_level))
+        conandata_yml = load_yml(conandata_path)
+        if not conandata_yml:
+            return
+        entries = _not_allowed_entries(list(conandata_yml.keys()), allowed_first_level)
+        if entries:
+            out.error("First level entries %s not allowed. Use only first level entries %s in "
+                      "conandata.yml" % (entries, allowed_first_level))
 
-            for entry in conandata_yml:
-                if entry in ['sources', 'patches']:
-                    if not isinstance(conandata_yml[entry], dict):
-                        out.error("Expecting a dictionary with versions as keys under '{}' element".format(entry))
-                    else:
-                        versions = conandata_yml[entry].keys()
-                        if any([not isinstance(it, str) for it in versions]):
-                            out.error("Versions in conandata.yml should be strings. Add quotes around the numbers")
+        for entry in conandata_yml:
+            if entry in ['sources', 'patches']:
+                if not isinstance(conandata_yml[entry], dict):
+                    out.error("Expecting a dictionary with versions as keys under '{}' element".format(entry))
+                else:
+                    versions = conandata_yml[entry].keys()
+                    if any([not isinstance(it, str) for it in versions]):
+                        out.error("Versions in conandata.yml should be strings. Add quotes around the numbers")
 
-                if version not in conandata_yml[entry]:
-                    continue
-                for element in conandata_yml[entry][version]:
-                    if entry == "patches":
-                        entries = _not_allowed_entries(element, allowed_patches)
-                        if entries:
-                            out.error("Additional entries %s not allowed in 'patches':'%s' of "
-                                      "conandata.yml" % (entries, version))
-                            return
-                    if entry == "sources":
-                        entries = _not_allowed_entries(element, allowed_sources)
-                        if entries:
-                            out.error("Additional entry %s not allowed in 'sources':'%s' of "
-                                      "conandata.yml" % (entries, version))
-                            return
+            if version not in conandata_yml[entry]:
+                continue
+            for element in conandata_yml[entry][version]:
+                if entry == "patches":
+                    entries = _not_allowed_entries(element, allowed_patches)
+                    if entries:
+                        out.error("Additional entries %s not allowed in 'patches':'%s' of "
+                                  "conandata.yml" % (entries, version))
+                        return
+                if entry == "sources":
+                    entries = _not_allowed_entries(element, allowed_sources)
+                    if entries:
+                        out.error("Additional entry %s not allowed in 'sources':'%s' of "
+                                  "conandata.yml" % (entries, version))
+                        return
 
     @run_test("KB-H034", output)
     def test(out):
@@ -509,6 +514,32 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
         if default_options and not isinstance(default_options, dict):
             out.error("Use a dictionary to declare 'default_options'")
 
+    @run_test("KB-H052", output)
+    def test(out):
+        config_path = os.path.abspath(os.path.join(export_folder_path, os.path.pardir, "config.yml"))
+        config_yml = load_yml(config_path)
+
+        conandata_path = os.path.join(export_folder_path, "conandata.yml")
+        conandata_yml = load_yml(conandata_path)
+
+        if not config_yml or not conandata_yml:
+            return
+
+        if 'versions' not in config_yml:
+            return
+
+        if 'sources' not in conandata_yml:
+            return
+
+        versions_conandata = conandata_yml['sources'].keys()
+        versions_config = config_yml['versions'].keys()
+
+        for version in versions_conandata:
+            if version not in versions_config:
+                out.error('The version "{}" exists in "{}" but not in "{}", so it will not be built.'
+                          ' Please update "{}" to include newly added '
+                          'version "{}".'.format(version, conandata_path, config_path, config_path,
+                                                 version))
 
 @raise_if_error_output
 def post_export(output, conanfile, conanfile_path, reference, **kwargs):
@@ -519,21 +550,19 @@ def post_export(output, conanfile, conanfile_path, reference, **kwargs):
         conandata_path = os.path.join(export_folder_path, "conandata.yml")
         version = conanfile.version
 
-        if os.path.exists(conandata_path):
-            conandata = tools.load(conandata_path)
-            conandata_yml = yaml.safe_load(conandata)
-            if not conandata_yml:
-                return
-            info = {}
-            for entry in conandata_yml:
-                if version not in conandata_yml[entry]:
-                    continue
-                info[entry] = {}
-                info[entry][version] = conandata_yml[entry][version]
-            out.info("Saving conandata.yml: {}".format(info))
-            new_conandata_yml = yaml.safe_dump(info, default_flow_style=False)
-            out.info("New conandata.yml contents: {}".format(new_conandata_yml))
-            tools.save(conandata_path, new_conandata_yml)
+        conandata_yml = load_yml(conandata_path)
+        if not conandata_yml:
+            return
+        info = {}
+        for entry in conandata_yml:
+            if version not in conandata_yml[entry]:
+                continue
+            info[entry] = {}
+            info[entry][version] = conandata_yml[entry][version]
+        out.info("Saving conandata.yml: {}".format(info))
+        new_conandata_yml = yaml.safe_dump(info, default_flow_style=False)
+        out.info("New conandata.yml contents: {}".format(new_conandata_yml))
+        tools.save(conandata_path, new_conandata_yml)
 
     @run_test("KB-H050", output)
     def test(out):

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -880,3 +880,37 @@ class ConanCenterTests(ConanClientTestCase):
         output = self.conan(['export', '.', 'name/version@user/test'])
         self.assertIn("ERROR: [DEFAULT SHARED OPTION VALUE (KB-H050)] The option 'shared' must be "
                       "'False' by default. Update 'default_options'.", output)
+
+    def test_missing_version_in_config(self):
+        tools.save(os.path.join('all', 'conanfile.py'), content=self.conanfile_base.format(placeholder=''))
+        conandata = textwrap.dedent("""
+                    sources:
+                        1.0:
+                           url: fakeurl
+                           md5: 12323423423
+                        2.0:
+                           url: fakeurl
+                           md5: 12323423423
+        """)
+        config = textwrap.dedent("""
+        versions:
+          1.0:
+            folder:all
+        """)
+        tools.save("config.yml", content=config)
+        tools.save(os.path.join("all", "conandata.yml"), content=conandata)
+        output = self.conan(['export', 'all', 'name/version@user/test'])
+        self.assertIn("ERROR: [CONFIG.YML HAS NEW VERSION (KB-H052)] The version \"2.0\" exists in",
+                      output)
+
+        config = textwrap.dedent("""
+        versions:
+          1.0:
+            folder:all
+          2.0:
+            folder:all
+        """)
+        tools.save("config.yml", content=config)
+        output = self.conan(['export', 'all', 'name/version@user/test'])
+        self.assertNotIn("ERROR: [CONFIG.YML HAS NEW VERSION (KB-H052)] The version \"2.0\" exists in",
+                         output)


### PR DESCRIPTION
this is a common mistake to add a new version to the `conandata.yml`, but forget to add it to the `config.yml`.
as result, CI doesn't build the newly added version, and we don't know if it actually passed the CI.
it's very easy to miss during the review, so I've decided to add an automatic check for human error.

NOTE: it's not needed to add the opposite case - version is added to the `config.yml` but not to the `conandata.yml`, as it would fail anyway during the attempt to fetch sources.

docs: https://github.com/conan-io/conan-center-index/pull/2640