### PR TITLE
- improve unicode check output

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -441,10 +441,21 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
     def test(out):
 
         def _check_non_ascii(filename, content):
+            import unicodedata
             for num, line in enumerate(content.splitlines(), 1):
-                if not all(ord(it) < 128 for it in line):
+                bad_chars = {num: char for num, char in enumerate(line, 1) if ord(char) >= 128}
+                if bad_chars:
                     out.error("The file '{}' contains a non-ascii character at line ({})."
                               " Only ASCII characters are allowed, please remove it.".format(filename, num))
+                    indexes = bad_chars.keys()
+                    draw = ['^' if i in indexes else ' ' for i in range(1, len(line))]
+                    draw = ''.join(draw)
+                    bad_chars = bad_chars.values()
+                    bad_chars = ["\\x%s (%s)" % (format(ord(c), 'x'), unicodedata.name(c)) for c in bad_chars]
+                    message = "bad characters: " + ' '.join(bad_chars)
+                    output.info(message)
+                    output.info(line)
+                    output.info(draw)
 
         _check_non_ascii("conanfile.py", conanfile_content)
         test_package_dir = os.path.join(os.path.dirname(conanfile_path), "test_package")


### PR DESCRIPTION
with the current hook it's hard to understand what exactly goes wrong...
the improved output looks like:
```
[HOOK - conan-center.py] pre_export(): ERROR: [NO ASCII CHARACTERS (KB-H047)] The file 'conanfile.py' contains a non-ascii character at line (49). Only ASCII characters are allowed, please remove it. (https://github.com/conan-io/conan-center-index/blob/master/docs/error_knowledge_base.md#KB-H047)
[HOOK - conan-center.py] pre_export(): bad characters: \xa0 (NO-BREAK SPACE)
[HOOK - conan-center.py] pre_export():         # the following conan dependencies are missing:
[HOOK - conan-center.py] pre_export():          ^
```