### PR TITLE
- do not output full paths

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -544,6 +544,8 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
 
         versions_conandata = conandata_yml['sources'].keys()
         versions_config = config_yml['versions'].keys()
+        conandata_path = os.path.relpath(conandata_path, export_folder_path)
+        config_path = os.path.relpath(config_path, export_folder_path)
 
         for version in versions_conandata:
             if version not in versions_config:


### PR DESCRIPTION
hotfix for https://github.com/conan-io/hooks/pull/223
don't display full paths (CI-specific path is useless for conan center user)