### PR TITLE
Use single line for multiple files

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -727,7 +727,7 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
             out.error("The conan-center repository doesn't allow the packages to contain `pc` "
                       "files. The packages have to "
                       "be located using generators and the declared `cpp_info` information")
-            out.error("Found files:\n{}".format("\n".join(bad_files)))
+            out.error("Found files: {}".format("; ".join(bad_files)))
 
     @run_test("KB-H016", output)
     def test(out):
@@ -740,14 +740,14 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
             out.error("The conan-center repository doesn't allow the packages to contain CMake "
                       "find modules or config files. The packages have to "
                       "be located using generators and the declared `cpp_info` information")
-            out.error("Found files:\n{}".format("\n".join(bad_files)))
+            out.error("Found files: {}".format("; ".join(bad_files)))
 
     @run_test("KB-H017", output)
     def test(out):
         bad_files = _get_files_following_patterns(conanfile.package_folder, ["*.pdb"])
         if bad_files:
             out.error("The conan-center repository doesn't allow PDB files")
-            out.error("Found files:\n{}".format("\n".join(bad_files)))
+            out.error("Found files: {}".format("; ".join(bad_files)))
 
     @run_test("KB-H018", output)
     def test(out):
@@ -755,7 +755,7 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
         if bad_files:
             out.error("Libtool files found (*.la). Do not package *.la files "
                       "but library files (.a) ")
-            out.error("Found files:\n{}".format("\n".join(bad_files)))
+            out.error("Found files: {}".format("; ".join(bad_files)))
 
     @run_test("KB-H021", output)
     def test(out):
@@ -763,7 +763,7 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
                                                   ["msvcr*.dll", "msvcp*.dll", "vcruntime*.dll", "concrt*.dll"])
         if bad_files:
             out.error("The conan-center repository doesn't allow Microsoft Visual Studio runtime files.")
-            out.error("Found files:\n{}".format("\n".join(bad_files)))
+            out.error("Found files: {}".format("; ".join(bad_files)))
 
 
 def post_package_info(output, conanfile, reference, **kwargs):
@@ -791,7 +791,7 @@ def post_package_info(output, conanfile, reference, **kwargs):
         if files_missplaced:
             out.error("The *.cmake files have to be placed in a folder declared as "
                       "`cpp_info.builddirs`. Currently folders declared: {}".format(build_dirs))
-            out.error("Found files:\n{}".format("\n".join(files_missplaced)))
+            out.error("Found files: {}".format("; ".join(files_missplaced)))
 
 
 def _get_files_following_patterns(folder, patterns):

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -740,6 +740,7 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
             out.error("The conan-center repository doesn't allow the packages to contain CMake "
                       "find modules or config files. The packages have to "
                       "be located using generators and the declared `cpp_info` information")
+
             out.error("Found files: {}".format("; ".join(bad_files)))
 
     @run_test("KB-H017", output)
@@ -802,7 +803,7 @@ def _get_files_following_patterns(folder, patterns):
                 for pattern in patterns:
                     if fnmatch.fnmatch(filename, pattern):
                         ret.append(os.path.join(root, filename).replace("\\", "/"))
-    return ret
+    return sorted(ret)
 
 
 def _get_files_with_extensions(folder, extensions):

--- a/tests/test_hooks/conan-center/test_cmake_bad_files.py
+++ b/tests/test_hooks/conan-center/test_cmake_bad_files.py
@@ -43,21 +43,36 @@ class ConanCMakeBadFiles(ConanClientTestCase):
 
         tools.save('conanfile.py', content=self.conan_file.format("", "WhateverConfig.cmake"))
         output = self.conan(['create', '.', 'name/version@user/channel'])
-        self.assertIn("ERROR: [CMAKE-MODULES-CONFIG-FILES (KB-H016)] Found files:\n./WhateverConfig.cmake",
+        self.assertIn("ERROR: [CMAKE-MODULES-CONFIG-FILES (KB-H016)] Found files: ./WhateverConfig.cmake",
                       output)
 
     def test_find_and_find_files(self):
-
         tools.save('conanfile.py', content=self.conan_file.format("", "FindXXX.cmake"))
         output = self.conan(['create', '.', 'name/version@user/channel'])
-        self.assertIn("ERROR: [CMAKE-MODULES-CONFIG-FILES (KB-H016)] Found files:\n./FindXXX.cmake",
+        self.assertIn("ERROR: [CMAKE-MODULES-CONFIG-FILES (KB-H016)] Found files: ./FindXXX.cmake",
+                      output)
+
+    def test_find_and_find_files_and_config_files(self):
+        conanfile = textwrap.dedent("""\
+            import os
+            from conans import ConanFile, tools
+
+            class AConan(ConanFile):
+
+                def package(self):
+                    tools.save(os.path.join(self.package_folder, "FindXXX.cmake"), "foo")
+                    tools.save(os.path.join(self.package_folder, "XXXConfig.cmake"), "foo")
+            """)
+        tools.save('conanfile.py', content=conanfile)
+        output = self.conan(['create', '.', 'name/version@user/channel'])
+        self.assertIn("ERROR: [CMAKE-MODULES-CONFIG-FILES (KB-H016)] Found files: ./XXXConfig.cmake; ./FindXXX.cmake",
                       output)
 
     def test_find_files_outside_dir(self):
 
         tools.save('conanfile.py', content=self.conan_file.format("folder", "file.cmake"))
         output = self.conan(['create', '.', 'name/version@user/channel'])
-        self.assertIn("ERROR: [CMAKE FILE NOT IN BUILD FOLDERS (KB-H019)] Found files:\n"
+        self.assertIn("ERROR: [CMAKE FILE NOT IN BUILD FOLDERS (KB-H019)] Found files: "
                       "./folder/file.cmake", output.replace("\\", "/"))
 
         tools.save('conanfile.py', content=self.conan_file.format("", "file.cmake"))
@@ -67,11 +82,11 @@ class ConanCMakeBadFiles(ConanClientTestCase):
         conanfile2 = textwrap.dedent("""\
                 import os
                 from conans import ConanFile, tools
-    
+
                 class AConan(ConanFile):
-    
+
                     def package(self):
-                        tools.save(os.path.join(self.package_folder, "{}", "file.cmake"), 
+                        tools.save(os.path.join(self.package_folder, "{}", "file.cmake"),
                                    "foo")
                     def package_info(self):
                         self.cpp_info.builddirs = ["some_build_dir"]

--- a/tests/test_hooks/conan-center/test_cmake_bad_files.py
+++ b/tests/test_hooks/conan-center/test_cmake_bad_files.py
@@ -65,7 +65,7 @@ class ConanCMakeBadFiles(ConanClientTestCase):
             """)
         tools.save('conanfile.py', content=conanfile)
         output = self.conan(['create', '.', 'name/version@user/channel'])
-        self.assertIn("ERROR: [CMAKE-MODULES-CONFIG-FILES (KB-H016)] Found files: ./XXXConfig.cmake; ./FindXXX.cmake",
+        self.assertIn("ERROR: [CMAKE-MODULES-CONFIG-FILES (KB-H016)] Found files: ./FindXXX.cmake; ./XXXConfig.cmake",
                       output)
 
     def test_find_files_outside_dir(self):


### PR DESCRIPTION
The hooks KB-H016, KB-H017, KB-H018, KB-H019, KB-H020 and KB-H021 use "\n" to show each file found by the hook. It works for logs, but for Github comments don't.

The idea here is printing all files at same line, but using ";" as separator. 

fixes https://github.com/conan-io/hooks/issues/230
fixes https://github.com/conan-io/conan-center-index/issues/2856