### PR TITLE
Skip poppler-data from KB-H014

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -707,7 +707,7 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
         if conanfile.version == "system":
             return
         # INFO: Whitelist for package names
-        if conanfile.name in ["ms-gsl", "cccl"]:
+        if conanfile.name in ["ms-gsl", "cccl", "poppler-data"]:
             return
         if not _files_match_settings(conanfile, conanfile.package_folder, out):
             out.error("Packaged artifacts does not match the settings used: os=%s, compiler=%s"


### PR DESCRIPTION
Poppler Data is header-only in terms of package id, but it only installs config files, so  KB-H014 is a bit angry.

Related to https://github.com/conan-io/conan-center-index/pull/2798

/cc @madebr 