### PR TITLE
Add ignition-cmake exception in KB-H016

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -758,7 +758,7 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
 
     @run_test("KB-H016", output)
     def test(out):
-        if conanfile.name in ["cmake", "msys2", "strawberryperl", "pybind11"]:
+        if conanfile.name in ["cmake", "msys2", "strawberryperl", "pybind11", "ignition-cmake"]:
             return
         bad_files = _get_files_following_patterns(conanfile.package_folder, ["Find*.cmake",
                                                                              "*Config.cmake",


### PR DESCRIPTION
`ignition-cmake` is a set of CMake modules that are used by the Ignition packages. Conan package PR: https://github.com/conan-io/conan-center-index/pull/3268