### PR TITLE
Skip KB-H016 and KB-H014 for extra-cmake-modules

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -733,8 +733,8 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
     def test(out):
         if conanfile.version == "system":
             return
-        # INFO: Whitelist for package names
-        if conanfile.name in ["ms-gsl", "cccl", "poppler-data"]:
+        # INFO: Allowlist for package names
+        if conanfile.name in ["ms-gsl", "cccl", "poppler-data", "extra-cmake-modules"]:
             return
         if not _files_match_settings(conanfile, conanfile.package_folder, out):
             out.error("Packaged artifacts does not match the settings used: os=%s, compiler=%s"
@@ -758,7 +758,8 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
 
     @run_test("KB-H016", output)
     def test(out):
-        if conanfile.name in ["cmake", "msys2", "strawberryperl", "pybind11", "ignition-cmake"]:
+        if conanfile.name in ["cmake", "msys2", "strawberryperl", "pybind11", "ignition-cmake",
+                              "extra-cmake-modules"]:
             return
         bad_files = _get_files_following_patterns(conanfile.package_folder, ["Find*.cmake",
                                                                              "*Config.cmake",


### PR DESCRIPTION
ECM is a collection of cmake file and both KB-H016; KB-H014 complains about.

Related to https://github.com/conan-io/conan-center-index/pull/3211