### PR TITLE
Add pdal to whitelist for KB-H050

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -608,7 +608,7 @@ def post_export(output, conanfile, conanfile_path, reference, **kwargs):
 
     @run_test("KB-H050", output)
     def test(out):
-        if conanfile.name in ["paho-mqtt-c", "tbb"]:
+        if conanfile.name in ["paho-mqtt-c", "tbb", "pdal"]:
             out.info("'{}' is part of the allowlist, skipping.".format(conanfile.name))
             return
 


### PR DESCRIPTION
Affects conan-io/conan-center-index#3443 .

pdal does not have static builds at all