### PR TITLE
Add hook to verify class name

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -56,6 +56,7 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H055": "SINGLE REQUIRES",
              "KB-H056": "LICENSE PUBLIC DOMAIN",
              "KB-H058": "ILLEGAL CHARACTERS",
+             "KB-H059": "CLASS NAME",
              }
 
 
@@ -622,6 +623,12 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
                 if file.endswith("."):
                     out.error("The file '{}' ends with a dot. Please, remove the dot from the end."
                               .format(file, disallowed_chars))
+
+    @run_test("KB-H059", output)
+    def test(out):
+        class_name = type(conanfile).__name__
+        if class_name in ("LibnameConan", "ConanRecipe", "ConanFileDefault"):
+            out.error("Class name '{}' is not allowed. For example, use '{}Conan' instead.".format(class_name, conanfile.name))
 
 
 @raise_if_error_output

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -629,7 +629,7 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
         class_name = type(conanfile).__name__
         if class_name in ("LibnameConan", "ConanFileDefault"):
             camel_name = "".join(s.title() for s in re.split("[^a-zA-Z0-9]", conanfile.name))
-            out.error("Class name '{}' is not allowed. For example, use '{}Conan' instead.".format(class_name, camel_name))
+            out.warn("Class name '{}' is not allowed. For example, use '{}Conan' instead.".format(class_name, camel_name))
 
 
 @raise_if_error_output

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -627,7 +627,7 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
     @run_test("KB-H059", output)
     def test(out):
         class_name = type(conanfile).__name__
-        if class_name in ("LibnameConan", "ConanRecipe", "ConanFileDefault"):
+        if class_name in ("LibnameConan", "ConanFileDefault"):
             out.error("Class name '{}' is not allowed. For example, use '{}Conan' instead.".format(class_name, conanfile.name))
 
 

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -628,7 +628,8 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
     def test(out):
         class_name = type(conanfile).__name__
         if class_name in ("LibnameConan", "ConanFileDefault"):
-            out.error("Class name '{}' is not allowed. For example, use '{}Conan' instead.".format(class_name, conanfile.name))
+            camel_name = "".join(s.title() for s in re.split("[^a-zA-Z0-9]", conanfile.name))
+            out.error("Class name '{}' is not allowed. For example, use '{}Conan' instead.".format(class_name, camel_name))
 
 
 @raise_if_error_output

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -1090,7 +1090,7 @@ class ConanCenterTests(ConanClientTestCase):
         """)
         tools.save('conanfile.py', content=conanfile)
         output = self.conan(['create', '.', 'name/version@user/test'])
-        self.assertIn("ERROR: [CLASS NAME (KB-H059)] Class name 'LibnameConan' is not allowed. For example, use 'NameConan' instead.", output)
+        self.assertIn("WARN: [CLASS NAME (KB-H059)] Class name 'LibnameConan' is not allowed. For example, use 'NameConan' instead.", output)
 
     def test_class_name_disallowed_dashed(self):
         conanfile = textwrap.dedent("""\
@@ -1100,4 +1100,4 @@ class ConanCenterTests(ConanClientTestCase):
         """)
         tools.save('conanfile.py', content=conanfile)
         output = self.conan(['create', '.', 'name-sdk/version@user/test'])
-        self.assertIn("ERROR: [CLASS NAME (KB-H059)] Class name 'LibnameConan' is not allowed. For example, use 'NameSdkConan' instead.", output)
+        self.assertIn("WARN: [CLASS NAME (KB-H059)] Class name 'LibnameConan' is not allowed. For example, use 'NameSdkConan' instead.", output)

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -1092,4 +1092,3 @@ class ConanCenterTests(ConanClientTestCase):
         tools.save('conanfile.py', content=conanfile)
         output = self.conan(['create', '.', 'name/version@user/test'])
         self.assertIn("ERROR: [CLASS NAME (KB-H059)] Class name 'LibnameConan' is not allowed. For example, use 'nameConan' instead.", output)
-

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -1086,7 +1086,6 @@ class ConanCenterTests(ConanClientTestCase):
         conanfile = textwrap.dedent("""\
         from conans import ConanFile
         class LibnameConan(ConanFile):
-            {}
             pass
         """)
         tools.save('conanfile.py', content=conanfile)

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -1096,7 +1096,6 @@ class ConanCenterTests(ConanClientTestCase):
         conanfile = textwrap.dedent("""\
         from conans import ConanFile
         class LibnameConan(ConanFile):
-            {}
             pass
         """)
         tools.save('conanfile.py', content=conanfile)

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -1091,4 +1091,15 @@ class ConanCenterTests(ConanClientTestCase):
         """)
         tools.save('conanfile.py', content=conanfile)
         output = self.conan(['create', '.', 'name/version@user/test'])
-        self.assertIn("ERROR: [CLASS NAME (KB-H059)] Class name 'LibnameConan' is not allowed. For example, use 'nameConan' instead.", output)
+        self.assertIn("ERROR: [CLASS NAME (KB-H059)] Class name 'LibnameConan' is not allowed. For example, use 'NameConan' instead.", output)
+
+    def test_class_name_disallowed_dashed(self):
+        conanfile = textwrap.dedent("""\
+        from conans import ConanFile
+        class LibnameConan(ConanFile):
+            {}
+            pass
+        """)
+        tools.save('conanfile.py', content=conanfile)
+        output = self.conan(['create', '.', 'name-sdk/version@user/test'])
+        self.assertIn("ERROR: [CLASS NAME (KB-H059)] Class name 'LibnameConan' is not allowed. For example, use 'NameSdkConan' instead.", output)

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -1081,3 +1081,15 @@ class ConanCenterTests(ConanClientTestCase):
         output = self.conan(['export', "conanfile.py", 'name/version@user/test'])
         self.assertIn("ERROR: [ILLEGAL CHARACTERS (KB-H058)] The file 'foo.' ends with a dot."
                       " Please, remove the dot from the end.", output)
+
+    def test_class_name_disallowed(self):
+        conanfile = textwrap.dedent("""\
+        from conans import ConanFile
+        class LibnameConan(ConanFile):
+            {}
+            pass
+        """)
+        tools.save('conanfile.py', content=conanfile)
+        output = self.conan(['create', '.', 'name/version@user/test'])
+        self.assertIn("ERROR: [CLASS NAME (KB-H059)] Class name 'LibnameConan' is not allowed. For example, use 'nameConan' instead.", output)
+


### PR DESCRIPTION
A few recipes have names like `LibnameConan`.
Preassigned id KB-H054.