### PR TITLE
 [KB-H050] add vulkan-loader to whitelist

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -608,7 +608,7 @@ def post_export(output, conanfile, conanfile_path, reference, **kwargs):
 
     @run_test("KB-H050", output)
     def test(out):
-        if conanfile.name in ["paho-mqtt-c", "tbb", "pdal"]:
+        if conanfile.name in ["paho-mqtt-c", "tbb", "pdal", "vulkan-loader"]:
             out.info("'{}' is part of the allowlist, skipping.".format(conanfile.name))
             return
 


### PR DESCRIPTION
`vulkan-loader` should always be shared (big warning in CMakeLists: https://github.com/KhronosGroup/Vulkan-Loader/blob/aed40d52837dba3850a27c61529de6fa25979d19/CMakeLists.txt#L45), except on Apple os where it's allowed to build it as a static lib.

Will allow https://github.com/conan-io/conan-center-index/pull/4308 to pass CI in CCI