### PR TITLE
[KB-H050] add opencl-icd-loader to whitelist

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -608,7 +608,7 @@ def post_export(output, conanfile, conanfile_path, reference, **kwargs):
 
     @run_test("KB-H050", output)
     def test(out):
-        if conanfile.name in ["paho-mqtt-c", "tbb", "pdal"]:
+        if conanfile.name in ["opencl-icd-loader", "paho-mqtt-c", "tbb", "pdal"]:
             out.info("'{}' is part of the allowlist, skipping.".format(conanfile.name))
             return
 


### PR DESCRIPTION
related to https://github.com/conan-io/conan-center-index/pull/4441

Recommendations from authors:
https://github.com/KhronosGroup/OpenCL-ICD-Loader/blob/1d5315c3ed30d026acb79a1aa53a276fc833ffa7/CMakeLists.txt#L9

> The option below allows building the ICD Loader library as a shared library
> (ON, default) or a static library (OFF).
> 
> Khronos OpenCL Working Group strongly recommends building and using the ICD
> loader as a shared library due to the following benefits:
> 
> 1. The shared library can be updated independent of the application. This
>    allows releasing new fixes and features in the ICD loader without updating
>    the application.
> 
>    In rare cases when there are backward-incompatible changes to the ICD
>    loader (due to platform requirements, for instance), using a shared
>    library allows updating the library to make the transition seamless to
>    installed applications.
> 
> 2. On platforms that require the ICD mechanism there are multiple vendors
>    shipping their OpenCL implementations. The vendor installers collaborate
>    to make sure that the installed ICD shared library version is suitable for
>    working with all vendor implementations installed on the system.
> 
>    If applications statically link to ICD Loader then that version of the ICD
>    loader may not work with one or more installed vendor implementations.
> 
> Using the OpenCL ICD loader as a static library is NOT recommended for
> end-user installations in general. However in some controlled environments it
> may be useful to simplify the build and distribution of the application. E.g.
> in test farms, or in cases where the end-user system configs are known in
> advance. Use it with discretion.