### PR TITLE
add powershell to KB-H021 whitelist

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -805,6 +805,8 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
 
     @run_test("KB-H021", output)
     def test(out):
+        if conanfile.name in ["powershell"]:
+            return
         bad_files = _get_files_following_patterns(conanfile.package_folder,
                                                   ["msvcr*.dll", "msvcp*.dll", "vcruntime*.dll", "concrt*.dll"])
         if bad_files:


### PR DESCRIPTION
The vcruntime dll packaged in `powershell` recipe is required to run `pwsh.exe` executable (which is the main purpose to create a recipe for powershell).

https://github.com/conan-io/conan-center-index/pull/4558