### PR TITLE
[hotfix] KB-H054 must not modify cpp_info

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -749,7 +749,7 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
     def test(out):
         if conanfile.version == "system":
             return
-        
+
         # INFO: Whitelist for package names
         if conanfile.name in ["ms-gsl", "cccl", "poppler-data", "extra-cmake-modules", "gnu-config", "autoconf", "automake"]:
             return
@@ -845,7 +845,7 @@ def post_package_info(output, conanfile, reference, **kwargs):
     @run_test("KB-H054", output)
     def test(out):
         def _test_component(component):
-            libs_to_search = component.libs
+            libs_to_search = component.libs.copy()
             for p in component.libdirs:
                 libs_found = tools.collect_libs(conanfile, p)
                 if not libs_found:

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -845,7 +845,7 @@ def post_package_info(output, conanfile, reference, **kwargs):
     @run_test("KB-H054", output)
     def test(out):
         def _test_component(component):
-            libs_to_search = component.libs.copy()
+            libs_to_search = list(component.libs)
             for p in component.libdirs:
                 libs_found = tools.collect_libs(conanfile, p)
                 if not libs_found:


### PR DESCRIPTION
After KB-H054 we started to have a lot of trouble in CCI, it seems like we fall for the Python prank :sweat_smile: 

Related to #273

Thanks to @SpaceIm for pointing us that bug! 

- Copy cpp_info.libs instead of using its reference
- Add new tests for KB-H054