### PR TITLE
Add logging level for conan-center hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,16 @@ variable ``CONAN_HOOK_ERROR_LEVEL``:
    - ``CONAN_HOOK_ERROR_LEVEL=40`` it will raise if any error happen.
    - ``CONAN_HOOK_ERROR_LEVEL=30`` it will raise if any error or warning happen.
 
+If you want to decrease logging level, you can adjust it by the environment variable
+``CONAN_HOOK_LOGGING_LEVEL``:
 
+  - ``CONAN_HOOK_LOGGING_LEVEL=40`` it will print out only error messages
+  - ``CONAN_HOOK_LOGGING_LEVEL=WARNING`` it will print out only warning and error messages
+
+It accepts both logging level names and logging level code:
+  - ERROR: 40
+  - WARNING/WARN: 30
+  - INFO: 20
 
 ### [Attribute checker](hooks/attribute_checker.py)
 


### PR DESCRIPTION
This PR is an extension of `CONAN_LOGGING_LEVEL`, but for Conan Center hook.

For local development we may not want to see all info, only warning and error are enough.


It's related to #279. Unfortunately we don't have a hook post-command yet, but we can silence minor messages at least.