### PR TITLE
Fix KB-H054 for header-only case

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -863,7 +863,7 @@ def post_package_info(output, conanfile, reference, **kwargs):
                 if not libs_found and not _is_recipe_header_only(conanfile):
                     out.warn("Component %s::%s libdir \"%s\" does not contain any library" % (conanfile.name, component.name, p))
                 libs_declared_and_found = [l for l in libs_found if l in libs_to_search]
-                if not libs_declared_and_found:
+                if not libs_declared_and_found and not _is_recipe_header_only(conanfile):
                     out.warn("Component %s::%s libdir \"%s\" does not contain any declared library" % (conanfile.name, component.name, p))
                 for l in libs_declared_and_found:
                     libs_to_search.remove(l)

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -859,6 +859,8 @@ def post_package_info(output, conanfile, reference, **kwargs):
         def _test_component(component):
             libs_to_search = list(component.libs)
             for p in component.libdirs:
+                libs_found = tools.collect_libs(conanfile, p)
+                libs_declared_and_found = [l for l in libs_found if l in libs_to_search]
                 for l in libs_declared_and_found:
                     libs_to_search.remove(l)
             for l in libs_to_search:

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -859,12 +859,6 @@ def post_package_info(output, conanfile, reference, **kwargs):
         def _test_component(component):
             libs_to_search = list(component.libs)
             for p in component.libdirs:
-                libs_found = tools.collect_libs(conanfile, p)
-                if not libs_found and not _is_recipe_header_only(conanfile):
-                    out.warn("Component %s::%s libdir \"%s\" does not contain any library" % (conanfile.name, component.name, p))
-                libs_declared_and_found = [l for l in libs_found if l in libs_to_search]
-                if not libs_declared_and_found and not _is_recipe_header_only(conanfile):
-                    out.warn("Component %s::%s libdir \"%s\" does not contain any declared library" % (conanfile.name, component.name, p))
                 for l in libs_declared_and_found:
                     libs_to_search.remove(l)
             for l in libs_to_search:

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -1026,4 +1026,3 @@ class ConanCenterTests(ConanClientTestCase):
         tools.save('conanfile.py', content=self.conanfile_header_only)
         output = self.conan(['create', '.', 'name/version@user/test'])
         self.assertIn("[LIBRARY DOES NOT EXIST (KB-H054)] OK", output)
-        self.assertNotIn('WARN: [LIBRARY DOES NOT EXIST (KB-H054)]', output)

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -1034,4 +1034,4 @@ class ConanCenterTests(ConanClientTestCase):
         tools.save('conanfile.py', content=self.conanfile_header_only)
         output = self.conan(['create', '.', 'name/version@user/test'])
         self.assertIn("[LIBRARY DOES NOT EXIST (KB-H054)] OK", output)
-        self.assertNotIn('does not contain any library', output)
+        self.assertNotIn('WARN: [LIBRARY DOES NOT EXIST (KB-H054)]', output)

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -998,14 +998,10 @@ class ConanCenterTests(ConanClientTestCase):
 
         output = self.conan(['create', '.', 'name/version@user/test'])
         self.assertIn("[LIBRARY DOES NOT EXIST (KB-H054)] OK", output)
-        self.assertIn('WARN: [LIBRARY DOES NOT EXIST (KB-H054)] Component '
-                      'name::name libdir "lib" does not contain any declared library', output)
 
         tools.save('conanfile.py', content=conanfile.replace("open", "# open"))
         output = self.conan(['create', '.', 'name/version@user/test'])
         self.assertIn("[LIBRARY DOES NOT EXIST (KB-H054)] OK", output)
-        self.assertIn('WARN: [LIBRARY DOES NOT EXIST (KB-H054)] Component '
-                      'name::name libdir "lib" does not contain any library', output)
 
         tools.save('conanfile.py', content=conanfile.replace("[]", "['bar']"))
         output = self.conan(['create', '.', 'name/version@user/test'])
@@ -1015,15 +1011,11 @@ class ConanCenterTests(ConanClientTestCase):
         tools.save('conanfile.py', content=conanfile.replace("libs", "components['fake'].libs"))
         output = self.conan(['create', '.', 'name/version@user/test'])
         self.assertIn("[LIBRARY DOES NOT EXIST (KB-H054)] OK", output)
-        self.assertIn('WARN: [LIBRARY DOES NOT EXIST (KB-H054)] Component '
-                      'name::fake libdir "lib" does not contain any declared library', output)
 
         tools.save('conanfile.py', content=conanfile.replace("libs", "components['fake'].libs")
                                                     .replace("open", "# open"))
         output = self.conan(['create', '.', 'name/version@user/test'])
         self.assertIn("[LIBRARY DOES NOT EXIST (KB-H054)] OK", output)
-        self.assertIn('WARN: [LIBRARY DOES NOT EXIST (KB-H054)] Component '
-                      'name::fake libdir "lib" does not contain any library', output)
 
         tools.save('conanfile.py', content=conanfile.replace("libs = []",
                                                              "components['fake'].libs = ['bar']"))


### PR DESCRIPTION
One missing case for this hook.

Related cases:

https://github.com/conan-io/conan-center-index/pull/4856/files#r593086602
https://github.com/conan-io/hooks/pull/278

UPDATE:

I removed all warning messages, because header-only is only the top of iceberg, we also need to filter deps components and local components, look what is consumed and what's not. For now we have false-positives which are not cool.

The hook 054 works good for its task, but I don't think those extra warning are relevant now.