### PR TITLE
Name attribute is mandatory

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -174,6 +174,8 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
                 if not field_value:
                     out_method("Conanfile doesn't have '%s' attribute. " % field)
 
+        if "    name =" not in conanfile_content:
+            out.error("Conanfile doesn't have 'name' attribute.")
         _message_attr(["url", "license", "description", "homepage", "topics"], out.error)
 
     @run_test("KB-H005", output)

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -19,6 +19,7 @@ class ConanCenterTests(ConanClientTestCase):
         from conans import ConanFile
 
         class AConan(ConanFile):
+            name = "name"
             url = "fake_url.com"
             license = "fake_license"
             description = "whatever"
@@ -34,6 +35,7 @@ class ConanCenterTests(ConanClientTestCase):
         from conans import ConanFile
 
         class AConan(ConanFile):
+            name = "name"
             url = "fake_url.com"
             license = "fake_license"
             description = "whatever"
@@ -52,6 +54,7 @@ class ConanCenterTests(ConanClientTestCase):
         from conans import ConanFile
 
         class AConan(ConanFile):
+            name = "name"
             url = "fake_url.com"
             license = "fake_license"
             description = "whatever"
@@ -70,6 +73,7 @@ class ConanCenterTests(ConanClientTestCase):
             from conans import ConanFile
 
             class Fpic(ConanFile):
+                name = "name"
                 url = "fake_url.com"
                 license = "fake_license"
                 description = "whatever"
@@ -426,6 +430,7 @@ class ConanCenterTests(ConanClientTestCase):
             pass
         """)
         bad_recipe_output = [
+            "ERROR: [RECIPE METADATA (KB-H003)] Conanfile doesn't have 'name' attribute.",
             "ERROR: [RECIPE METADATA (KB-H003)] Conanfile doesn't have 'url' attribute.",
             "ERROR: [RECIPE METADATA (KB-H003)] Conanfile doesn't have 'license' attribute.",
             "ERROR: [RECIPE METADATA (KB-H003)] Conanfile doesn't have 'description' attribute.",


### PR DESCRIPTION
Unfortunately `getattr` doesn't work, because Conan injects `name` from package reference. We have to check directly in file content. 


closes #282

