### PR TITLE
Remove fPIC when building shared

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -718,7 +718,7 @@ def pre_build(output, conanfile, **kwargs):
             out.error("'fPIC' option not managed correctly. Please remove it for Windows "
                       "configurations: del self.options.fpic")
             error = True
-        if conanfile.options.get_safe("fPIC") and conanfile.options.get_safe("shared"):
+        if has_fpic and conanfile.options.get_safe("shared"):
             out.error("'fPIC' option not managed correctly. Please remove it for shared "
                       "option: del self.options.fpic")
             error = True

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -713,10 +713,16 @@ def pre_build(output, conanfile, **kwargs):
     @run_test("KB-H007", output)
     def test(out):
         has_fpic = conanfile.options.get_safe("fPIC")
+        error = False
         if conanfile.settings.get_safe("os") == "Windows" and has_fpic:
             out.error("'fPIC' option not managed correctly. Please remove it for Windows "
                       "configurations: del self.options.fpic")
-        elif has_fpic:
+            error = True
+        if conanfile.options.get_safe("fPIC") and conanfile.options.get_safe("shared"):
+            out.error("'fPIC' option not managed correctly. Please remove it for shared "
+                      "option: del self.options.fpic")
+            error = True
+        elif has_fpic and not error:
             out.success("OK. 'fPIC' option found and apparently well managed")
         else:
             out.info("'fPIC' option not found")

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -335,6 +335,10 @@ class ConanCenterTests(ConanClientTestCase):
         else:
             self.assertIn("[FPIC MANAGEMENT (KB-H007)] OK. 'fPIC' option found and apparently " \
                         "well managed", output)
+        output = self.conan(['create', '.', 'package/version@conan/test', '-o package:shared=True'])
+        self.assertIn("ERROR: [FPIC MANAGEMENT (KB-H007)] 'fPIC' option not managed " \
+                        "correctly. Please remove it for shared " \
+                        "option: del self.options.fpic", output)
 
     def test_fpic_remove_windows(self):
         conanfile = textwrap.dedent("""\


### PR DESCRIPTION
It's recommendation well followed. More than 300 recipes in CCI are using it.

Wiki: https://github.com/conan-io/conan-center-index/pull/5002


closes #285