### PR TITLE
Fix license check in spdx_checker + case-sensitive check

### DIFF
--- a/hooks/spdx_checker.py
+++ b/hooks/spdx_checker.py
@@ -13,7 +13,7 @@ def check_license(output, license_id):
 def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
     del conanfile_path, reference, kwargs
 
-    if "license" not in conanfile.__dict__:
+    if getattr(conanfile, "license", None) is None:
         output.info("recipe doesn't have a license attribute")
         return
     if isinstance(conanfile.license, str):

--- a/hooks/spdx_checker.py
+++ b/hooks/spdx_checker.py
@@ -4,7 +4,9 @@ import spdx_lookup
 
 
 def check_license(output, license_id):
-    if spdx_lookup.by_id(license_id):
+    license_value = spdx_lookup.by_id(license_id)
+    # use case-sensitive check
+    if license_value and license_value.id == license_id:
         output.info('license "%s" is a valid SPDX license identifier' % license_id)
     else:
         output.error('license "%s" is not a valid SPDX license identifier' % license_id)


### PR DESCRIPTION
Two fixes for spdx_checker:
- properly locate `license` (thanks to #129)
- case-sensitive check for names

Please note that `spdx-lookup` and `spdx` Python packages are archived and no longer supported therefore a license list is greatly outdated compared to [actual list](https://github.com/spdx/license-list-data) (see #246). This hook should be used only for informative purposes.