### PR TITLE
KB-H014: MinGW accepts .lib extensions

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -924,7 +924,7 @@ def _shared_files_well_managed(conanfile, folder):
 def _files_match_settings(conanfile, folder, output):
     header_extensions = ["h", "h++", "hh", "hxx", "hpp"]
     visual_extensions = ["lib", "dll", "exe", "bat"]
-    mingw_extensions = ["a", "a.dll", "dll", "exe", "sh"]
+    mingw_extensions = ["a", "lib", "a.dll", "dll", "exe", "sh"]
     # The "" extension is allowed to look for possible executables
     linux_extensions = ["a", "so", "sh", ""]
     freebsd_extensions = ["a", "so", "sh", ""]


### PR DESCRIPTION
Some libraries, like libdeflate, create .lib static or import lib, even for MinGW.

(`.lib` extension is allowed by MinGW, but such files must be linked with full name (without extension), even the lib prefix.
e.g: static lib file name of libdeflate is `libdeflatestatic.lib` for MinGW, so link option is `-llibdeflatestatic`)