### PR TITLE
[fix] Add decorator to raise if failure in post_package_info

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -838,6 +838,7 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
             out.error("Found files: {}".format("; ".join(bad_files)))
 
 
+@raise_if_error_output
 def post_package_info(output, conanfile, reference, **kwargs):
 
     @run_test("KB-H019", output)


### PR DESCRIPTION
Fix for: https://github.com/conan-io/conan-center-index/pull/4528

It might affect other packages or PRs