### PR TITLE
Relax hook from `post_package_info`, breaks on requirements

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -864,9 +864,9 @@ def post_package_info(output, conanfile, reference, **kwargs):
                 files_missplaced.append(filename)
 
         if files_missplaced:
-            out.error("The *.cmake files have to be placed in a folder declared as "
-                      "`cpp_info.builddirs`. Currently folders declared: {}".format(build_dirs))
-            out.error("Found files: {}".format("; ".join(files_missplaced)))
+            out.warn("The *.cmake files have to be placed in a folder declared as "
+                     "`cpp_info.builddirs`. Currently folders declared: {}".format(build_dirs))
+            out.warn("Found files: {}".format("; ".join(files_missplaced)))
 
 
     @run_test("KB-H054", output)

--- a/tests/test_hooks/conan-center/test_cmake_bad_files.py
+++ b/tests/test_hooks/conan-center/test_cmake_bad_files.py
@@ -72,12 +72,12 @@ class ConanCMakeBadFiles(ConanClientTestCase):
 
         tools.save('conanfile.py', content=self.conan_file.format("folder", "file.cmake"))
         output = self.conan(['create', '.', 'name/version@user/channel'])
-        self.assertIn("ERROR: [CMAKE FILE NOT IN BUILD FOLDERS (KB-H019)] Found files: "
+        self.assertIn("WARN: [CMAKE FILE NOT IN BUILD FOLDERS (KB-H019)] Found files: "
                       "./folder/file.cmake", output.replace("\\", "/"))
 
         tools.save('conanfile.py', content=self.conan_file.format("", "file.cmake"))
         output = self.conan(['create', '.', 'name/version@user/channel'])
-        self.assertNotIn("ERROR: [CMAKE FILE NOT IN BUILD FOLDERS (KB-H019)]", output)
+        self.assertNotIn("WARN: [CMAKE FILE NOT IN BUILD FOLDERS (KB-H019)]", output)
 
         conanfile2 = textwrap.dedent("""\
                 import os
@@ -94,11 +94,11 @@ class ConanCMakeBadFiles(ConanClientTestCase):
 
         tools.save('conanfile.py', content=conanfile2.format("some_build_dir"))
         output = self.conan(['create', '.', 'name/version@user/channel'])
-        self.assertNotIn("ERROR: [CMAKE FILE NOT IN BUILD FOLDERS (KB-H019)]", output)
+        self.assertNotIn("WARN: [CMAKE FILE NOT IN BUILD FOLDERS (KB-H019)]", output)
 
         tools.save('conanfile.py', content=conanfile2.format("some_build_dir/subdir"))
         output = self.conan(['create', '.', 'name/version@user/channel'])
-        self.assertNotIn("ERROR: [CMAKE FILE NOT IN BUILD FOLDERS (KB-H019)]", output)
+        self.assertNotIn("WARN: [CMAKE FILE NOT IN BUILD FOLDERS (KB-H019)]", output)
 
     def test_good_files(self):
         tools.save('conanfile.py', content=self.conan_file_info.format('os.path.join("lib", "cmake", "script.cmake")', ["lib/cmake"]))


### PR DESCRIPTION
After merging https://github.com/conan-io/hooks/pull/299, PRs have started to fail because of requirements. This cannot be an error unless we control that it raises only for the recipe being modified in the PR (example: https://github.com/conan-io/conan-center-index/pull/5722)