### PR TITLE
KB-H060 No CRLF allowed

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -56,6 +56,7 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H055": "SINGLE REQUIRES",
              "KB-H056": "LICENSE PUBLIC DOMAIN",
              "KB-H058": "ILLEGAL CHARACTERS",
+             "KB-H059": "NO CRLF",
              }
 
 
@@ -622,6 +623,16 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
                 if file.endswith("."):
                     out.error("The file '{}' ends with a dot. Please, remove the dot from the end."
                               .format(file, disallowed_chars))
+
+    @run_test("KB-H059", output)
+    def test(out):
+        recipe_folder = os.path.dirname(conanfile_path)
+        for root, _, files in os.walk(recipe_folder):
+            for filename in files:
+                lines = open(os.path.join(root, filename), 'rb').readlines()
+                if any(line.endswith(b'\r\n') for line in lines):
+                    out.error("The file '{}' uses CRLF. Please, replace by LF."
+                              .format(filename))
 
 
 @raise_if_error_output

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -56,7 +56,7 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H055": "SINGLE REQUIRES",
              "KB-H056": "LICENSE PUBLIC DOMAIN",
              "KB-H058": "ILLEGAL CHARACTERS",
-             "KB-H059": "NO CRLF",
+             "KB-H060": "NO CRLF",
              }
 
 
@@ -624,7 +624,7 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
                     out.error("The file '{}' ends with a dot. Please, remove the dot from the end."
                               .format(file, disallowed_chars))
 
-    @run_test("KB-H059", output)
+    @run_test("KB-H060", output)
     def test(out):
         recipe_folder = os.path.dirname(conanfile_path)
         for root, _, files in os.walk(recipe_folder):

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 import os
+import io
 import platform
 import textwrap
 import pytest
@@ -1081,3 +1082,15 @@ class ConanCenterTests(ConanClientTestCase):
         output = self.conan(['export', "conanfile.py", 'name/version@user/test'])
         self.assertIn("ERROR: [ILLEGAL CHARACTERS (KB-H058)] The file 'foo.' ends with a dot."
                       " Please, remove the dot from the end.", output)
+
+    def test_no_crlf(self):
+        conanfile = "from conans import ConanFile\nclass AConan(ConanFile):\n    pass\n"
+
+        tools.save('conanfile.py', content=conanfile)
+        output = self.conan(['export', 'conanfile.py', 'name/version@user/test'])
+        self.assertIn("[NO CRLF (KB-H059)] OK", output)
+
+        with io.open('conanfile.py', 'w', newline='\r\n') as f_handle:
+            f_handle.write(conanfile)
+        output = self.conan(['export', 'conanfile.py', 'name/version@user/test'])
+        self.assertIn("ERROR: [NO CRLF (KB-H059)] The file 'conanfile.py' uses CRLF. Please, replace by LF.", output)

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -1084,7 +1084,7 @@ class ConanCenterTests(ConanClientTestCase):
                       " Please, remove the dot from the end.", output)
 
     def test_no_crlf(self):
-        conanfile = "from conans import ConanFile\nclass AConan(ConanFile):\n    pass\n"
+        conanfile = u"from conans import ConanFile\nclass AConan(ConanFile):\n    pass\n"
 
         tools.save('conanfile.py', content=conanfile)
         output = self.conan(['export', 'conanfile.py', 'name/version@user/test'])

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -1088,9 +1088,9 @@ class ConanCenterTests(ConanClientTestCase):
 
         tools.save('conanfile.py', content=conanfile)
         output = self.conan(['export', 'conanfile.py', 'name/version@user/test'])
-        self.assertIn("[NO CRLF (KB-H059)] OK", output)
+        self.assertIn("[NO CRLF (KB-H060)] OK", output)
 
         with io.open('conanfile.py', 'w', newline='\r\n') as f_handle:
             f_handle.write(conanfile)
         output = self.conan(['export', 'conanfile.py', 'name/version@user/test'])
-        self.assertIn("ERROR: [NO CRLF (KB-H059)] The file 'conanfile.py' uses CRLF. Please, replace by LF.", output)
+        self.assertIn("ERROR: [NO CRLF (KB-H060)] The file 'conanfile.py' uses CRLF. Please, replace by LF.", output)


### PR DESCRIPTION
closes #313

This hook opens all files in binary more, look for and endline and check which characters are used.

In case CRLF is found, an error is raised, pointing the file path and to replace CRLF by LF only.