### PR TITLE
KB-H060 Read only gitattribute

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -634,13 +634,16 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
 
     @run_test("KB-H060", output)
     def test(out):
-        allowed_ext = [".cmake", ".conf", ".cfg", ".diff", ".md", ".patch", ".py", ".txt", ".yml", ".am", ".xml", ".json", ".in", ".ac", ".tsx", ".tmx", ".proto", ".capnp", ".c", ".cc", ".c++", ".cpp", ".cxx", ".c++m", ".cppm", ".cxxm", ".h++", ".hh", ".hxx", ".hpp"]
+        ext_to_be_checked = [".cmake", ".conf", ".cfg", ".diff", ".md", ".patch", ".py", ".txt",
+                             ".yml", ".am", ".xml", ".json", ".in", ".ac", ".tsx", ".tmx"
+                             ".proto", ".capnp", ".c", ".cc", ".c++", ".cpp", ".cxx", ".c++m",
+                             ".cppm", ".cxxm", ".h++", ".hh", ".hxx", ".hpp", ".qrc", ".pro", ".build "]
         recipe_folder = os.path.dirname(conanfile_path)
         for root, _, files in os.walk(recipe_folder):
             if os.path.relpath(root, recipe_folder).replace("\\", "/").startswith("test_package/build"):
                 continue
             for filename in files:
-                if not any(filename.endswith(ext) for ext in allowed_ext):
+                if not any(filename.endswith(ext) for ext in ext_to_be_checked):
                     continue
                 lines = open(os.path.join(root, filename), 'rb').readlines()
                 if any(line.endswith(b'\r\n') for line in lines):

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -634,7 +634,7 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
 
     @run_test("KB-H060", output)
     def test(out):
-        allowed_ext = [".cmake", ".conf", ".diff", ".md", ".patch", ".py", ".txt", ".yml", ".am", ".xml", ".json"]
+        allowed_ext = [".cmake", ".conf", ".cfg", ".diff", ".md", ".patch", ".py", ".txt", ".yml", ".am", ".xml", ".json", ".in", ".ac", ".tsx", ".tmx", ".proto", ".capnp", ".c", ".cc", ".c++", ".cpp", ".cxx", ".c++m", ".cppm", ".cxxm", ".h++", ".hh", ".hxx", ".hpp"]
         recipe_folder = os.path.dirname(conanfile_path)
         for root, _, files in os.walk(recipe_folder):
             if os.path.relpath(root, recipe_folder).replace("\\", "/").startswith("test_package/build"):

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -637,7 +637,7 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
         ext_to_be_checked = [".cmake", ".conf", ".cfg", ".diff", ".md", ".patch", ".py", ".txt",
                              ".yml", ".am", ".xml", ".json", ".in", ".ac", ".tsx", ".tmx"
                              ".proto", ".capnp", ".c", ".cc", ".c++", ".cpp", ".cxx", ".c++m",
-                             ".cppm", ".cxxm", ".h++", ".hh", ".hxx", ".hpp", ".qrc", ".pro", ".build "]
+                             ".cppm", ".cxxm", ".h++", ".hh", ".hxx", ".hpp", ".qrc", ".pro", ".build"]
         recipe_folder = os.path.dirname(conanfile_path)
         for root, _, files in os.walk(recipe_folder):
             if os.path.relpath(root, recipe_folder).replace("\\", "/").startswith("test_package/build"):

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -634,11 +634,14 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
 
     @run_test("KB-H060", output)
     def test(out):
+        allowed_ext = [".cmake", ".conf", ".diff", ".md", ".patch", ".py", ".txt", ".yml", ".am"]
         recipe_folder = os.path.dirname(conanfile_path)
         for root, _, files in os.walk(recipe_folder):
             if os.path.relpath(root, recipe_folder).replace("\\", "/").startswith("test_package/build"):
                 continue
             for filename in files:
+                if not any(filename.endswith(ext) for ext in allowed_ext):
+                    continue
                 lines = open(os.path.join(root, filename), 'rb').readlines()
                 if any(line.endswith(b'\r\n') for line in lines):
                     out.error("The file '{}' uses CRLF. Please, replace by LF."

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -634,7 +634,7 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
 
     @run_test("KB-H060", output)
     def test(out):
-        allowed_ext = [".cmake", ".conf", ".diff", ".md", ".patch", ".py", ".txt", ".yml", ".am"]
+        allowed_ext = [".cmake", ".conf", ".diff", ".md", ".patch", ".py", ".txt", ".yml", ".am", ".xml", ".json"]
         recipe_folder = os.path.dirname(conanfile_path)
         for root, _, files in os.walk(recipe_folder):
             if os.path.relpath(root, recipe_folder).replace("\\", "/").startswith("test_package/build"):

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -643,7 +643,7 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
             if os.path.relpath(root, recipe_folder).replace("\\", "/").startswith("test_package/build"):
                 continue
             for filename in files:
-                if not any(filename.endswith(ext) for ext in ext_to_be_checked):
+                if not any(filename.lower().endswith(ext) for ext in ext_to_be_checked):
                     continue
                 lines = open(os.path.join(root, filename), 'rb').readlines()
                 if any(line.endswith(b'\r\n') for line in lines):

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -637,7 +637,8 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
         ext_to_be_checked = [".cmake", ".conf", ".cfg", ".diff", ".md", ".patch", ".py", ".txt",
                              ".yml", ".am", ".xml", ".json", ".in", ".ac", ".tsx", ".tmx",
                              ".proto", ".capnp", ".c", ".cc", ".c++", ".cpp", ".cxx", ".c++m",
-                             ".cppm", ".cxxm", ".h++", ".hh", ".hxx", ".hpp", ".qrc", ".pro", ".build"]
+                             ".cppm", ".cxxm", ".h++", ".hh", ".hxx", ".hpp", ".qrc", ".pro",
+                             ".build", ".s", ".asm"]
         recipe_folder = os.path.dirname(conanfile_path)
         for root, _, files in os.walk(recipe_folder):
             if os.path.relpath(root, recipe_folder).replace("\\", "/").startswith("test_package/build"):

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -635,7 +635,7 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
     @run_test("KB-H060", output)
     def test(out):
         ext_to_be_checked = [".cmake", ".conf", ".cfg", ".diff", ".md", ".patch", ".py", ".txt",
-                             ".yml", ".am", ".xml", ".json", ".in", ".ac", ".tsx", ".tmx"
+                             ".yml", ".am", ".xml", ".json", ".in", ".ac", ".tsx", ".tmx",
                              ".proto", ".capnp", ".c", ".cc", ".c++", ".cpp", ".cxx", ".c++m",
                              ".cppm", ".cxxm", ".h++", ".hh", ".hxx", ".hpp", ".qrc", ".pro", ".build"]
         recipe_folder = os.path.dirname(conanfile_path)

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -1119,5 +1119,7 @@ class ConanCenterTests(ConanClientTestCase):
         tools.mkdir(os.path.join('test_package', 'build'))
         with io.open(os.path.join('test_package', 'build', 'conanfile.py'), 'w', newline='\r\n') as f_handle:
             f_handle.write(conanfile)
+        with io.open(os.path.join('conanfile.ttf'), 'w', newline='\r\n') as f_handle:
+            f_handle.write(conanfile)
         output = self.conan(['export', 'conanfile.py', 'name/version@user/test'])
         self.assertIn("[NO CRLF (KB-H060)] OK", output)


### PR DESCRIPTION
Reading .gitattibute file would be a problem, as we only have the recipe folder path. It could use relative path, or even a git python library to load it, but I think is too much.

Let's use the common extensions listed in .gitattribute file, it should cover 99% of our cases.

I also added .json .xml in case some exotic project need an extra configuration file(Boost and Qt for instance) or even for some json parser which uses a json file in test_package

/cc @SpaceIm