### PR TITLE
Disallow tools.os_info and platform in requirements/build_requirements/config_options/configure/validate

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -700,11 +700,11 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
             def visit_Attribute(self, node):
                 methods_stack_no_build_info_allowed = [fdef for fdef in self.function_def_stack if fdef in self.METHODS_NO_BUILDINFO]
                 if methods_stack_no_build_info_allowed:
-                    # FIXME: Not all python 2.7 interpretors have node.end_lineno
+                    # FIXME: Not all python 2.7 interpretors have node.end_lineno or node.end_col_offset
                     if node.attr == "os_info" and isinstance(node.value, ast.Name) and node.value.id == "tools":
-                        self.invalids.append(BuildInfo(Location(node.lineno, node.col_offset, getattr(node, "end_lineno", node.lineno), node.end_col_offset), "tools.os_info", methods_stack_no_build_info_allowed[0]))
+                        self.invalids.append(BuildInfo(Location(node.lineno, node.col_offset, getattr(node, "end_lineno", node.lineno), getattr(node, "end_col_offset", node.col_offset)), "tools.os_info", methods_stack_no_build_info_allowed[0]))
                     elif isinstance(node.value, ast.Name) and node.value.id == "platform":
-                        self.invalids.append(BuildInfo(Location(node.lineno, node.col_offset, getattr(node, "end_lineno", node.lineno), node.end_col_offset), "platform", methods_stack_no_build_info_allowed[0]))
+                        self.invalids.append(BuildInfo(Location(node.lineno, node.col_offset, getattr(node, "end_lineno", node.lineno), getattr(node, "end_col_offset", node.col_offset)), "platform", methods_stack_no_build_info_allowed[0]))
                 self.generic_visit(node)
 
         to_test = [(conanfile_path, conanfile_content),]

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -713,7 +713,11 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
             to_test.append((test_conanfile_path, tools.load(test_conanfile_path)))
 
         for dut_conanfile_path, dut_conanfile_contents in to_test:
-            node = ast.parse(dut_conanfile_contents)
+            try:
+                node = ast.parse(dut_conanfile_contents)
+            except SyntaxError:
+                out.error("A SyntaxError was thrown while parsing '{}'".format(dut_conanfile_path))
+                continue
             visitor = BuildInfoVisitor()
             visitor.visit(node)
             for build_info in visitor.invalids:

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -143,8 +143,8 @@ def run_test(kb_id, output):
                 out.success("OK")
             return ret
         except Exception as e:
-            out.error("Exception raised from hook: {}".format(e))
-            raise e
+            out.error("Exception raised from hook: {} (type={})".format(e, type(e).__name__))
+            raise
 
     return tmp
 

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -700,10 +700,11 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
             def visit_Attribute(self, node):
                 methods_stack_no_build_info_allowed = [fdef for fdef in self.function_def_stack if fdef in self.METHODS_NO_BUILDINFO]
                 if methods_stack_no_build_info_allowed:
+                    # FIXME: Not all python 2.7 interpretors have node.end_lineno
                     if node.attr == "os_info" and isinstance(node.value, ast.Name) and node.value.id == "tools":
-                        self.invalids.append(BuildInfo(Location(node.lineno, node.col_offset, node.end_lineno, node.end_col_offset), "tools.os_info", methods_stack_no_build_info_allowed[0]))
+                        self.invalids.append(BuildInfo(Location(node.lineno, node.col_offset, getattr(node, "end_lineno", node.lineno), node.end_col_offset), "tools.os_info", methods_stack_no_build_info_allowed[0]))
                     elif isinstance(node.value, ast.Name) and node.value.id == "platform":
-                        self.invalids.append(BuildInfo(Location(node.lineno, node.col_offset, node.end_lineno, node.end_col_offset), "platform", methods_stack_no_build_info_allowed[0]))
+                        self.invalids.append(BuildInfo(Location(node.lineno, node.col_offset, getattr(node, "end_lineno", node.lineno), node.end_col_offset), "platform", methods_stack_no_build_info_allowed[0]))
                 self.generic_visit(node)
 
         to_test = [(conanfile_path, conanfile_content),]

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -681,6 +681,7 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
                 "config_options",
                 "configure",
                 "package_id",
+                "package_info",
                 "requirements",
                 "source",
                 "validate",

--- a/tests/test_hooks/conan-center/test_build_info.py
+++ b/tests/test_hooks/conan-center/test_build_info.py
@@ -112,10 +112,6 @@ class TestBuildInfo(ConanClientTestCase):
             from conans import ConanFile, tools
 
             class AConan(ConanFile):
-                options = {
-                    "fPIC": [True, False],
-                }
-
                 def config_options(self):
                     if tools.os_info.is_windows:
                         del self.options.fPIC
@@ -123,7 +119,7 @@ class TestBuildInfo(ConanClientTestCase):
         output = self.conan(["export", ".", "name/version@user/channel"])
         self.assertIn("ERROR: [NO BUILD SYSTEM FUNCTIONS (KB-H061)]", output)
         self.assertIn("Use of tools.os_info is forbidden in config_options", output)
-        self.assertIn("conanfile.py:9 Build system dependent", output)
+        self.assertIn("conanfile.py:5 Build system dependent", output)
 
     def test_configopts_platform(self):
         tools.save("conanfile.py", textwrap.dedent("""\
@@ -131,10 +127,6 @@ class TestBuildInfo(ConanClientTestCase):
             import platform
 
             class AConan(ConanFile):
-                options = {
-                    "fPIC": [True, False],
-                }
-
                 def config_options(self):
                     if platform.system == "Windows":
                         del self.options.fPIC
@@ -142,17 +134,13 @@ class TestBuildInfo(ConanClientTestCase):
         output = self.conan(["export", ".", "name/version@user/channel"])
         self.assertIn("ERROR: [NO BUILD SYSTEM FUNCTIONS (KB-H061)]", output)
         self.assertIn("Use of platform is forbidden in config_options", output)
-        self.assertIn("conanfile.py:10 Build system dependent", output)
+        self.assertIn("conanfile.py:6 Build system dependent", output)
 
     def test_config_toolsosinfo(self):
         tools.save("conanfile.py", textwrap.dedent("""\
             from conans import ConanFile, tools
 
             class AConan(ConanFile):
-                options = {
-                    "fPIC": [True, False],
-                }
-
                 def configure(self):
                     if tools.os_info.is_windows:
                         del self.options.fPIC
@@ -160,7 +148,7 @@ class TestBuildInfo(ConanClientTestCase):
         output = self.conan(["export", ".", "name/version@user/channel"])
         self.assertIn("ERROR: [NO BUILD SYSTEM FUNCTIONS (KB-H061)]", output)
         self.assertIn("Use of tools.os_info is forbidden in configure", output)
-        self.assertIn("conanfile.py:9 Build system dependent", output)
+        self.assertIn("conanfile.py:5 Build system dependent", output)
 
     def test_config_platform(self):
         tools.save("conanfile.py", textwrap.dedent("""\
@@ -168,10 +156,6 @@ class TestBuildInfo(ConanClientTestCase):
             import platform
 
             class AConan(ConanFile):
-                options = {
-                    "fPIC": [True, False],
-                }
-
                 def configure(self):
                     if platform.system == "Windows":
                         del self.options.fPIC
@@ -179,7 +163,7 @@ class TestBuildInfo(ConanClientTestCase):
         output = self.conan(["export", ".", "name/version@user/channel"])
         self.assertIn("ERROR: [NO BUILD SYSTEM FUNCTIONS (KB-H061)]", output)
         self.assertIn("Use of platform is forbidden in configure", output)
-        self.assertIn("conanfile.py:10 Build system dependent", output)
+        self.assertIn("conanfile.py:6 Build system dependent", output)
 
     def test_validate_toolsosinfo(self):
         tools.save("conanfile.py", textwrap.dedent("""\
@@ -187,10 +171,6 @@ class TestBuildInfo(ConanClientTestCase):
             from conans.errors import ConanInvalidConfiguration
 
             class AConan(ConanFile):
-                options = {
-                    "fPIC": [True, False],
-                }
-
                 def validate(self):
                     if tools.os_info.is_windows:
                         raise ConanInvalidConfiguration("I refuse to build on Windows")
@@ -198,7 +178,7 @@ class TestBuildInfo(ConanClientTestCase):
         output = self.conan(["export", ".", "name/version@user/channel"])
         self.assertIn("ERROR: [NO BUILD SYSTEM FUNCTIONS (KB-H061)]", output)
         self.assertIn("Use of tools.os_info is forbidden in validate", output)
-        self.assertIn("conanfile.py:10 Build system dependent", output)
+        self.assertIn("conanfile.py:6 Build system dependent", output)
 
     def test_validate_platform(self):
         tools.save("conanfile.py", textwrap.dedent("""\
@@ -207,10 +187,6 @@ class TestBuildInfo(ConanClientTestCase):
             import platform
 
             class AConan(ConanFile):
-                options = {
-                    "fPIC": [True, False],
-                }
-
                 def validate(self):
                     if platform.system == "Windows":
                         raise ConanInvalidConfiguration("I refuse to build on Windows")
@@ -218,4 +194,4 @@ class TestBuildInfo(ConanClientTestCase):
         output = self.conan(["export", ".", "name/version@user/channel"])
         self.assertIn("ERROR: [NO BUILD SYSTEM FUNCTIONS (KB-H061)]", output)
         self.assertIn("Use of platform is forbidden in validate", output)
-        self.assertIn("conanfile.py:11 Build system dependent", output)
+        self.assertIn("conanfile.py:7 Build system dependent", output)

--- a/tests/test_hooks/conan-center/test_build_info.py
+++ b/tests/test_hooks/conan-center/test_build_info.py
@@ -1,0 +1,221 @@
+import os
+import textwrap
+
+from conans import tools
+
+from tests.utils.test_cases.conan_client import ConanClientTestCase
+
+
+class TestBuildInfo(ConanClientTestCase):
+
+    def _get_environ(self, **kwargs):
+        kwargs = super(TestBuildInfo, self)._get_environ(**kwargs)
+        kwargs.update({"CONAN_HOOKS": os.path.join(os.path.dirname(__file__), "..", "..", "..",
+                                                   "hooks", "conan-center")})
+        return kwargs
+
+    def test_trivial_ok(self):
+        tools.save("conanfile.py", content=textwrap.dedent("""\
+            from conans import ConanFile
+
+            class AConan(ConanFile):
+                pass
+            """))
+        output = self.conan(["export", ".", "name/version@user/channel"])
+        self.assertIn("[NO BUILD SYSTEM FUNCTIONS (KB-H061)] OK", output)
+
+    def test_build_toolsosinfo_ok(self):
+        tools.save("conanfile.py", content=textwrap.dedent("""\
+            from conans import ConanFile, tools
+
+            class AConan(ConanFile):
+                def build(self):
+                    if tools.os_info.is_windows:
+                        print("We're on Windows")
+            """))
+        output = self.conan(["export", ".", "name/version@user/channel"])
+        self.assertIn("[NO BUILD SYSTEM FUNCTIONS (KB-H061)] OK", output)
+
+    def test_build_platform_ok(self):
+        tools.save("conanfile.py", content=textwrap.dedent("""\
+            from conans import ConanFile
+            import platform
+
+            class AConan(ConanFile):
+                def build(self):
+                    if platform.system() == "Linux":
+                        print("We're on Linux")
+            """))
+        output = self.conan(["export", ".", "name/version@user/channel"])
+        self.assertIn("[NO BUILD SYSTEM FUNCTIONS (KB-H061)] OK", output)
+
+    def test_buildreq_toolsosinfo(self):
+        tools.save("conanfile.py", textwrap.dedent("""\
+            from conans import ConanFile, tools
+
+            class AConan(ConanFile):
+                def build_requirements(self):
+                    if tools.os_info.is_windows and not tools.get_env("CONAN_BASH_PATH"):
+                        self.build_requires("msys2/cci.latest")
+            """))
+        output = self.conan(["export", ".", "name/version@user/channel"])
+        self.assertIn("ERROR: [NO BUILD SYSTEM FUNCTIONS (KB-H061)]", output)
+        self.assertIn("Use of tools.os_info is forbidden in build_requirements", output)
+        self.assertIn("conanfile.py:5 Build system dependent", output)
+
+    def test_buildreq_platform(self):
+        tools.save("conanfile.py", textwrap.dedent("""\
+            from conans import ConanFile, tools
+            import platform
+
+            class AConan(ConanFile):
+                def build_requirements(self):
+                    if platform.system() == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
+                        self.build_requires("msys2/cci.latest")
+            """))
+        output = self.conan(["export", ".", "name/version@user/channel"])
+        self.assertIn("ERROR: [NO BUILD SYSTEM FUNCTIONS (KB-H061)]", output)
+        self.assertIn("Use of platform is forbidden in build_requirements", output)
+        self.assertIn("conanfile.py:6 Build system dependent", output)
+
+    def test_req_toolsosinfo(self):
+        tools.save("conanfile.py", textwrap.dedent("""\
+            from conans import ConanFile, tools
+
+            class AConan(ConanFile):
+                def requirements(self):
+                    if tools.os_info.is_linux:
+                        self.requires("libalsa/1.2.4")
+            """))
+        output = self.conan(["export", ".", "name/version@user/channel"])
+        self.assertIn("ERROR: [NO BUILD SYSTEM FUNCTIONS (KB-H061)]", output)
+        self.assertIn("Use of tools.os_info is forbidden in requirements", output)
+        self.assertIn("conanfile.py:5 Build system dependent", output)
+
+    def test_req_platform(self):
+        tools.save("conanfile.py", textwrap.dedent("""\
+            from conans import ConanFile, tools
+            import platform
+
+            class AConan(ConanFile):
+                def requirements(self):
+                    if platform.system() == "Linux":
+                        self.requires("libalsa/1.2.4")
+            """))
+        output = self.conan(["export", ".", "name/version@user/channel"])
+        self.assertIn("ERROR: [NO BUILD SYSTEM FUNCTIONS (KB-H061)]", output)
+        self.assertIn("Use of platform is forbidden in requirements", output)
+        self.assertIn("conanfile.py:6 Build system dependent", output)
+
+    def test_configopts_toolsosinfo(self):
+        tools.save("conanfile.py", textwrap.dedent("""\
+            from conans import ConanFile, tools
+
+            class AConan(ConanFile):
+                options = {
+                    "fPIC": [True, False],
+                }
+
+                def config_options(self):
+                    if tools.os_info.is_windows:
+                        del self.options.fPIC
+            """))
+        output = self.conan(["export", ".", "name/version@user/channel"])
+        self.assertIn("ERROR: [NO BUILD SYSTEM FUNCTIONS (KB-H061)]", output)
+        self.assertIn("Use of tools.os_info is forbidden in config_options", output)
+        self.assertIn("conanfile.py:9 Build system dependent", output)
+
+    def test_configopts_platform(self):
+        tools.save("conanfile.py", textwrap.dedent("""\
+            from conans import ConanFile, tools
+            import platform
+
+            class AConan(ConanFile):
+                options = {
+                    "fPIC": [True, False],
+                }
+
+                def config_options(self):
+                    if platform.system == "Windows":
+                        del self.options.fPIC
+            """))
+        output = self.conan(["export", ".", "name/version@user/channel"])
+        self.assertIn("ERROR: [NO BUILD SYSTEM FUNCTIONS (KB-H061)]", output)
+        self.assertIn("Use of platform is forbidden in config_options", output)
+        self.assertIn("conanfile.py:10 Build system dependent", output)
+
+    def test_config_toolsosinfo(self):
+        tools.save("conanfile.py", textwrap.dedent("""\
+            from conans import ConanFile, tools
+
+            class AConan(ConanFile):
+                options = {
+                    "fPIC": [True, False],
+                }
+
+                def configure(self):
+                    if tools.os_info.is_windows:
+                        del self.options.fPIC
+            """))
+        output = self.conan(["export", ".", "name/version@user/channel"])
+        self.assertIn("ERROR: [NO BUILD SYSTEM FUNCTIONS (KB-H061)]", output)
+        self.assertIn("Use of tools.os_info is forbidden in configure", output)
+        self.assertIn("conanfile.py:9 Build system dependent", output)
+
+    def test_config_platform(self):
+        tools.save("conanfile.py", textwrap.dedent("""\
+            from conans import ConanFile, tools
+            import platform
+
+            class AConan(ConanFile):
+                options = {
+                    "fPIC": [True, False],
+                }
+
+                def configure(self):
+                    if platform.system == "Windows":
+                        del self.options.fPIC
+            """))
+        output = self.conan(["export", ".", "name/version@user/channel"])
+        self.assertIn("ERROR: [NO BUILD SYSTEM FUNCTIONS (KB-H061)]", output)
+        self.assertIn("Use of platform is forbidden in configure", output)
+        self.assertIn("conanfile.py:10 Build system dependent", output)
+
+    def test_validate_toolsosinfo(self):
+        tools.save("conanfile.py", textwrap.dedent("""\
+            from conans import ConanFile, tools
+            from conans.errors import ConanInvalidConfiguration
+
+            class AConan(ConanFile):
+                options = {
+                    "fPIC": [True, False],
+                }
+
+                def validate(self):
+                    if tools.os_info.is_windows:
+                        raise ConanInvalidConfiguration("I refuse to build on Windows")
+            """))
+        output = self.conan(["export", ".", "name/version@user/channel"])
+        self.assertIn("ERROR: [NO BUILD SYSTEM FUNCTIONS (KB-H061)]", output)
+        self.assertIn("Use of tools.os_info is forbidden in validate", output)
+        self.assertIn("conanfile.py:10 Build system dependent", output)
+
+    def test_validate_platform(self):
+        tools.save("conanfile.py", textwrap.dedent("""\
+            from conans import ConanFile, tools
+            from conans.errors import ConanInvalidConfiguration
+            import platform
+
+            class AConan(ConanFile):
+                options = {
+                    "fPIC": [True, False],
+                }
+
+                def validate(self):
+                    if platform.system == "Windows":
+                        raise ConanInvalidConfiguration("I refuse to build on Windows")
+            """))
+        output = self.conan(["export", ".", "name/version@user/channel"])
+        self.assertIn("ERROR: [NO BUILD SYSTEM FUNCTIONS (KB-H061)]", output)
+        self.assertIn("Use of platform is forbidden in validate", output)
+        self.assertIn("conanfile.py:11 Build system dependent", output)


### PR DESCRIPTION
In recent weeks, c3i infrastructure + cci recipes received a lot of attention regarding cross building:
- c3i now builds/tests package on armv8 on Macos
- @SpaceIm updated **a lot** of recipes to support cross building to Apple's M1.

While doing so, it became clear that the use of `tools.os_info` and `platform` is troublesome if host profile != build profile.
This is even more important for c3i because the arbiter (=entity that sends builds jobs to linux/windows/macos machines) runs on Linux.
So it becomes important that all checks inside `config_options/configure/validate/requirements/build_requirements` do **not** depend on e.g. `tools.os_info.is_windows` or the `platform` module.

See e.g. the following comments (and more):
- https://github.com/conan-io/conan-center-index/pull/6348#discussion_r671041074
- https://github.com/conan-io/conan-center-index/pull/6371#discussion_r671368466

Instead of `tools.os_info.XXX`, we/I propose to use `self.settings_build` (if available).
See https://github.com/conan-io/conan-center-index/pull/6371#discussion_r671382902

So the following python code:
```python
def build_requirements(self):
    if tools.os_info.is_windows and not tools.get_env("CONAN_BASH_PATH"):
        self.build_requires("msys2/cci.latest")
```
can be replaced with:
```python
@property
def _settings_build(self):
    return getattr(self, "settings_build", self.settings)

def build_requirements(self):
    if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
        self.build_requires("msys2/cci.latest")
```

This alternative method, which is cross compile proof, has been successfully used by @SpaceIm in the last days.