### PR TITLE
add 'autoconf-archive' to the whitelist of package names for the KB-H014 hook

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -838,7 +838,7 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
 
         # INFO: Whitelist for package names
         if conanfile.name in ["ms-gsl", "cccl", "poppler-data", "extra-cmake-modules", "gnu-config",
-                              "autoconf", "automake", "xorg-macros"]:
+                              "autoconf", "automake", "xorg-macros", "autoconf-archive"]:
             return
         if not _files_match_settings(conanfile, conanfile.package_folder, out):
             out.error("Packaged artifacts does not match the settings used: os=%s, compiler=%s"


### PR DESCRIPTION
There is a PR to add autoconf-archive to conan-center-index, see https://github.com/conan-io/conan-center-index/pull/6702  but it fails the KB-H014 hook.

autoconf-archive is a collection of m4 macros similar to xorg-macros (?) which is already in the whitelist.