### PR TITLE
[conan-center] Validate topics attribute

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -59,7 +59,8 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H058": "ILLEGAL CHARACTERS",
              "KB-H059": "CLASS NAME",
              "KB-H060": "NO CRLF",
-             "KB-H062": "TOOLS CROSS BUILDING"
+             "KB-H062": "TOOLS CROSS BUILDING",
+             "KB-H064": "INVALID TOPICS",
              }
 
 
@@ -681,6 +682,16 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
         if os.path.exists(test_package_path):
             test_package_content = tools.load(test_package_path)
             _check_content(test_package_content, test_package_path)
+
+    @run_test("KB-H064", output)
+    def test(out):
+        topics = getattr(conanfile, "topics")
+        if topics and isinstance(topics, (list, tuple)):
+            invalid_topics = ["conan"]
+            for topic in topics:
+                if topic in invalid_topics:
+                    out.warn("The topic '{}' is invalid and should be removed from topics "
+                             "attribute.".format(topic))
 
 
 @raise_if_error_output

--- a/tests/test_hooks/conan-center/test_invalid_topics.py
+++ b/tests/test_hooks/conan-center/test_invalid_topics.py
@@ -1,0 +1,37 @@
+import os
+import textwrap
+
+from conans import tools
+
+from tests.utils.test_cases.conan_client import ConanClientTestCase
+
+
+class TestInvalidTopics(ConanClientTestCase):
+    conanfile = textwrap.dedent("""\
+        from conans import ConanFile
+        class AConan(ConanFile):
+            topics = ("foobar",)
+            pass
+        """)
+
+    def _get_environ(self, **kwargs):
+        kwargs = super(TestInvalidTopics, self)._get_environ(**kwargs)
+        kwargs.update({'CONAN_HOOKS': os.path.join(os.path.dirname(__file__), '..', '..', '..',
+                                                   'hooks', 'conan-center')})
+        return kwargs
+
+    def test_valid_topics(self):
+        tools.save('conanfile.py', content=self.conanfile)
+        output = self.conan(['export', '.', 'name/version@user/channel'])
+        self.assertIn("[INVALID TOPICS (KB-H064)] OK", output)
+
+    def test_no_topics(self):
+        tools.save('conanfile.py', content=self.conanfile.replace('topics = ("foobar",)', ""))
+        output = self.conan(['export', '.', 'name/version@user/channel'])
+        self.assertIn("[INVALID TOPICS (KB-H064)] OK", output)
+
+    def test_invalid_topics(self):
+        tools.save('conanfile.py', content=self.conanfile.replace('"foobar",', '"foobar", "conan"'))
+        output = self.conan(['export', '.', 'name/version@user/channel'])
+        self.assertIn("WARN: [INVALID TOPICS (KB-H064)] The topic 'conan' is invalid and should be"
+                      " removed from topics attribute.", output)


### PR DESCRIPTION
Due the high number of recipes using "conan" as topic, we can not set this hook as error, it would break many packages in Conan Center. Let's use Warning level, which is good enough.

close #334