### PR TITLE
Exclude mono from default package layout.

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -903,7 +903,7 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
 
     @run_test("KB-H013", output)
     def test(out):
-        if conanfile.name in ["cmake", "android-ndk", "zulu-openjdk", "mingw-w64", "openjdk"]:
+        if conanfile.name in ["cmake", "android-ndk", "zulu-openjdk", "mingw-w64", "openjdk", "mono"]:
             return
 
         base_known_folders = ["lib", "bin", "include", "res", "licenses"]


### PR DESCRIPTION
See https://github.com/conan-io/conan-center-index/pull/7239#issuecomment-920732232

For mono we need to keep the `etc` directory.