### PR TITLE
[tests] Move py versions

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -35,30 +35,61 @@ pipeline {
                         }
                     }
                 }
-                stage('Windows - py38') {
+                stage('Windows - py36') {
                     agent {
                         label 'Windows'
                     }
                     stages {
-                        stage('Windows - py38 - Generate environment') {
+                        stage('Windows - py36 - Generate environment') {
                             environment {
-                                PYVER = 'py38'
+                                PYVER = 'py36'
                             }
                             steps {
                                 bat '.ci/generate_env_windows.bat'
                             }
                         }
-                        stage('Windows - py38 - conanprev') {
+                        stage('Windows - py36 - conancurrent') {
                             environment {
-                                TOXENV = 'py38-conanprev'
+                                TOXENV = 'py36-conancurrent'
                             }
                             steps {
                                 bat 'tox'
                             }
                         }
-                        stage('Windows - py38 - conanprevprev') {
+                        stage('Windows - py36 - conanprev') {
                             environment {
-                                TOXENV = 'py38-conanprevprev'
+                                TOXENV = 'py36-conanprev'
+                            }
+                            steps {
+                                bat 'tox'
+                            }
+                        }
+                    }
+                }
+                stage('Windows - py39') {
+                    agent {
+                        label 'Windows'
+                    }
+                    stages {
+                        stage('Windows - py39 - Generate environment') {
+                            environment {
+                                PYVER = 'py39'
+                            }
+                            steps {
+                                bat '.ci/generate_env_windows.bat'
+                            }
+                        }
+                        stage('Windows - py39 - conancurrent') {
+                            environment {
+                                TOXENV = 'py39-conancurrent'
+                            }
+                            steps {
+                                bat 'tox'
+                            }
+                        }
+                        stage('Windows - py39 - conanprev') {
+                            environment {
+                                TOXENV = 'py39-conanprev'
                             }
                             steps {
                                 bat 'tox'
@@ -110,22 +141,22 @@ pipeline {
                         }
                     }
                 }
-                stage('Linux - py38') {
+                stage('Linux - py39') {
                     agent {
                         label 'Linux'
                     }
                     stages {
-                        stage('Linux - py38 - Generate environment') {
+                        stage('Linux - py39 - Generate environment') {
                             environment {
-                                PYVER = 'py38'
+                                PYVER = 'py39'
                             }
                             steps {
                                 sh '.ci/generate_env_linux.sh'
                             }
                         }
-                        stage('Linux - py38 - conandev') {
+                        stage('Linux - py39 - conandev') {
                             environment {
-                                TOXENV = 'py38-conandev'
+                                TOXENV = 'py39-conandev'
                             }
                             steps {
                                 sh '''
@@ -135,9 +166,9 @@ pipeline {
                                 '''
                             }
                         }
-                        stage('Linux - py38 - conancurrent') {
+                        stage('Linux - py39 - conancurrent') {
                             environment {
-                                TOXENV = 'py38-conancurrent'
+                                TOXENV = 'py39-conancurrent'
                             }
                             steps {
                                 sh '''
@@ -147,9 +178,9 @@ pipeline {
                                 '''
                             }
                         }
-                        stage('Linux - py38 - conanprev') {
+                        stage('Linux - py39 - conanprev') {
                             environment {
-                                TOXENV = 'py38-conanprev'
+                                TOXENV = 'py39-conanprev'
                             }
                             steps {
                                 sh '''
@@ -159,9 +190,9 @@ pipeline {
                                 '''
                             }
                         }
-                        stage('Linux - py38 - conanprevprev') {
+                        stage('Linux - py39 - conanprevprev') {
                             environment {
-                                TOXENV = 'py38-conanprevprev'
+                                TOXENV = 'py39-conanprevprev'
                             }
                             steps {
                                 sh '''

--- a/.ci/generate_env_linux.sh
+++ b/.ci/generate_env_linux.sh
@@ -7,32 +7,24 @@ eval "$(pyenv init -)"
 
 case "${PYVER}" in
     py27)
-        pyenv install 2.7.17
-        pyenv virtualenv 2.7.17 conan
-        ;;
-    py33)
-        pyenv install 3.3.7
-        pyenv virtualenv 3.3.7 conan
-        ;;
-    py34)
-        pyenv install 3.4.10
-        pyenv virtualenv 3.4.10 conan
-        ;;
-    py35)
-        pyenv install 3.5.9
-        pyenv virtualenv 3.5.9 conan
+        pyenv install 2.7.18
+        pyenv virtualenv 2.7.18 conan
         ;;
     py36)
-        pyenv install 3.6.10
-        pyenv virtualenv 3.6.10 conan
+        pyenv install 3.6.15
+        pyenv virtualenv 3.6.15 conan
         ;;
     py37)
-        pyenv install 3.7.6
-        pyenv virtualenv 3.7.6 conan
+        pyenv install 3.7.12
+        pyenv virtualenv 3.7.12 conan
         ;;
     py38)
-        pyenv install 3.8.1
-        pyenv virtualenv 3.8.1 conan
+        pyenv install 3.8.12
+        pyenv virtualenv 3.8.12 conan
+        ;;
+    py39)
+        pyenv install 3.9.7
+        pyenv virtualenv 3.9.7 conan
         ;;
 esac
 

--- a/.ci/generate_env_linux.sh
+++ b/.ci/generate_env_linux.sh
@@ -11,20 +11,20 @@ case "${PYVER}" in
         pyenv virtualenv 2.7.18 conan
         ;;
     py36)
-        pyenv install 3.6.15
-        pyenv virtualenv 3.6.15 conan
+        pyenv install 3.6.14
+        pyenv virtualenv 3.6.14 conan
         ;;
     py37)
-        pyenv install 3.7.12
-        pyenv virtualenv 3.7.12 conan
+        pyenv install 3.7.11
+        pyenv virtualenv 3.7.11 conan
         ;;
     py38)
-        pyenv install 3.8.12
-        pyenv virtualenv 3.8.12 conan
+        pyenv install 3.8.11
+        pyenv virtualenv 3.8.11 conan
         ;;
     py39)
-        pyenv install 3.9.7
-        pyenv virtualenv 3.9.7 conan
+        pyenv install 3.9.6
+        pyenv virtualenv 3.9.6 conan
         ;;
 esac
 

--- a/.ci/generate_env_linux.sh
+++ b/.ci/generate_env_linux.sh
@@ -11,20 +11,20 @@ case "${PYVER}" in
         pyenv virtualenv 2.7.18 conan
         ;;
     py36)
-        pyenv install 3.6.14
-        pyenv virtualenv 3.6.14 conan
+        pyenv install 3.6.15
+        pyenv virtualenv 3.6.15 conan
         ;;
     py37)
-        pyenv install 3.7.11
-        pyenv virtualenv 3.7.11 conan
+        pyenv install 3.7.12
+        pyenv virtualenv 3.7.12 conan
         ;;
     py38)
-        pyenv install 3.8.11
-        pyenv virtualenv 3.8.11 conan
+        pyenv install 3.8.12
+        pyenv virtualenv 3.8.12 conan
         ;;
     py39)
-        pyenv install 3.9.6
-        pyenv virtualenv 3.9.6 conan
+        pyenv install 3.9.7
+        pyenv virtualenv 3.9.7 conan
         ;;
 esac
 

--- a/.ci/generate_env_linux.sh
+++ b/.ci/generate_env_linux.sh
@@ -11,20 +11,20 @@ case "${PYVER}" in
         pyenv virtualenv 2.7.18 conan
         ;;
     py36)
-        pyenv install 3.6.15
-        pyenv virtualenv 3.6.15 conan
+        pyenv install 3.6.12
+        pyenv virtualenv 3.6.12 conan
         ;;
     py37)
         pyenv install 3.7.12
         pyenv virtualenv 3.7.12 conan
         ;;
     py38)
-        pyenv install 3.8.12
-        pyenv virtualenv 3.8.12 conan
+        pyenv install 3.8.6
+        pyenv virtualenv 3.8.6 conan
         ;;
     py39)
-        pyenv install 3.9.7
-        pyenv virtualenv 3.9.7 conan
+        pyenv install 3.9.2
+        pyenv virtualenv 3.9.2 conan
         ;;
 esac
 

--- a/.ci/generate_env_windows.bat
+++ b/.ci/generate_env_windows.bat
@@ -3,7 +3,7 @@ pip install tox==3.7.0 tox-venv==0.3.1 requests virtualenv
 python .ci/last_conan_version.py
 
 IF "%PYVER%"=="py39" (
-    set PYVER="Python39-64"
+    set PYVER="Python39"
 )
 IF "%PYVER%"=="py38" (
     set PYVER="Python38-64"

--- a/.ci/generate_env_windows.bat
+++ b/.ci/generate_env_windows.bat
@@ -2,6 +2,9 @@ set PATH=%PATH%;C:/Python36/Scripts/
 pip install tox==3.7.0 tox-venv==0.3.1 requests virtualenv
 python .ci/last_conan_version.py
 
+IF "%PYVER%"=="py39" (
+    set PYVER="Python39-64"
+)
 IF "%PYVER%"=="py38" (
     set PYVER="Python38-64"
 )


### PR DESCRIPTION
Let's keep as a general rule the following python versions:
 * (not strictly required) `py27` until Conan stops testing it or we can no longer run this tests
 * `py36` minimum version required according to tribe. **It is also the version we run in C3i**
 * `py<latest>`. Latest python version, it is likely the one used by most of consumers. 

---

These tests are running in the Linux image of Conan CI. That container hasn't been regenerated for a while and available Python versions are quite old (cc/ @czoido)... I'm using the same ones I see here https://github.com/conan-io/conan_ci_jenkins/blob/master/resources/org/jfrog/conanci/python_runner/conf.py#L19 because they are already available in the image and we don't need to install/build them each time. Alternatively, if we really want to run the latest patch version, we should use our own image and keep it updated.