### PR TITLE
Skip emsdk from KB-H020

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -953,7 +953,7 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
 
     @run_test("KB-H020", output)
     def test(out):
-        if conanfile.name in ["cmake", "msys2", "strawberryperl", "android-ndk"]:
+        if conanfile.name in ["cmake", "msys2", "strawberryperl", "android-ndk", "emsdk"]:
             return
         bad_files = _get_files_following_patterns(conanfile.package_folder, ["*.pc"])
         if bad_files:


### PR DESCRIPTION
For https://github.com/conan-io/conan-center-index/pull/6163

Two things I'm learning here:

- [ ] Probably we should maintain a list of _cross-compilers_ so they are all added to a list, and the same list is used in all the hooks that apply to them.
- [ ] (To check) All the hooks run and print their message before raising the error?