### PR TITLE
Suppress "Lib folder doesn't exist, can't collect libraries" warning

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1,10 +1,7 @@
-import conans.client.output
 import ast
 import collections
-import contextlib
 import fnmatch
 import inspect
-import io
 import os
 import re
 from logging import WARNING, ERROR, INFO, DEBUG, NOTSET
@@ -1042,8 +1039,9 @@ def post_package_info(output, conanfile, reference, **kwargs):
         def _test_component(component):
             libs_to_search = list(component.libs)
             for p in component.libdirs:
-                with _redirect_output(conanfile):
-                    libs_found = tools.collect_libs(conanfile, p)
+                if not os.path.isdir(p):
+                    continue
+                libs_found = tools.collect_libs(conanfile, p)
                 libs_declared_and_found = [l for l in libs_found if l in libs_to_search]
                 for l in libs_declared_and_found:
                     libs_to_search.remove(l)
@@ -1178,15 +1176,3 @@ def _get_os(conanfile):
     if not settings:
         return None
     return settings.get_safe("os") or settings.get_safe("os_build")
-
-
-@contextlib.contextmanager
-def _redirect_output(conanfile, output=None):
-    if not output:
-        stdout = io.StringIO()
-        stderr = io.StringIO()
-        output = conans.client.output.ConanOutput(stdout, stderr)
-
-    output, conanfile.output = conanfile.output, output
-    yield
-    output, conanfile.output = conanfile.output, output

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -1188,3 +1188,16 @@ class ConanCenterTests(ConanClientTestCase):
                                                              "tools.cross_building(self.settings)"))
         output = self.conan(['export', 'conanfile.py', 'name/version@user/test'])
         self.assertIn("WARN: [TOOLS CROSS BUILDING (KB-H062)] The 'tools.cross_building(self.settings)' syntax in conanfile.py",output)
+
+    def test_no_collect_libs_warning(self):
+        conanfile = textwrap.dedent("""\
+            from conans import ConanFile
+
+            class AConan(ConanFile):
+                def package_info(self):
+                    pass
+        """)
+
+        tools.save('conanfile.py', content=conanfile)
+        output = self.conan(['create', 'conanfile.py', 'name/version@user/test'])
+        self.assertNotIn("Lib folder doesn't exist, can't collect libraries", output)


### PR DESCRIPTION
A lot of header-only, binary-only recipe caused the following warning to be shown:
```
arm-toolchain/2021.07: WARN: Lib folder doesn't exist, can't collect libraries: C:\J\w\BuildSingleReference@9\.conan\data\arm-toolchain\2021.07\_\_\package\04f2c7df808cbf30fb74c1c554e1e55af1d01f82\lib
```

This is due to a call to `tools.collect_libs` in the hooks.
~This pr redirects the output temporarily during this call.~
This pr avoids calling collect_libs when the lib dir does not exist.