### PR TITLE
[ci] Time to remove Python 2 from CI

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -4,37 +4,6 @@ pipeline {
         stage("Windows") {
             failFast true
             parallel {
-                stage('Windows - py27') {
-                    agent {
-                        label 'Windows'
-                    }
-                    stages {
-                        stage('Windows - py27 - Generate environment') {
-                            environment {
-                                PYVER = 'py27'
-                            }
-                            steps {
-                                bat '.ci/generate_env_windows.bat'
-                            }
-                        }
-                        stage('Windows - py27 - conandev') {
-                            environment {
-                                TOXENV = 'py27-conandev'
-                            }
-                            steps {
-                                bat 'tox'
-                            }
-                        }
-                        stage('Windows - py27 - conancurrent') {
-                            environment {
-                                TOXENV = 'py27-conancurrent'
-                            }
-                            steps {
-                                bat 'tox'
-                            }
-                        }
-                    }
-                }
                 stage('Windows - py36') {
                     agent {
                         label 'Windows'

--- a/.ci/generate_env_linux.sh
+++ b/.ci/generate_env_linux.sh
@@ -6,10 +6,6 @@ set -x
 eval "$(pyenv init -)"
 
 case "${PYVER}" in
-    py27)
-        pyenv install 2.7.18
-        pyenv virtualenv 2.7.18 conan
-        ;;
     py36)
         pyenv install 3.6.12
         pyenv virtualenv 3.6.12 conan

--- a/.ci/generate_env_windows.bat
+++ b/.ci/generate_env_windows.bat
@@ -11,9 +11,6 @@ IF "%PYVER%"=="py38" (
 IF "%PYVER%"=="py36" (
     set PYVER="Python36"
 )
-IF "%PYVER%"=="py27" (
-    set PYVER="Python27"
-)
 set TEST_FOLDER=D:/J/t/Hooks/%BUILD_NUMBER%/%PYVER%
 
 virtualenv --python "C:/%PYVER%/python.exe" %TEST_FOLDER% && %TEST_FOLDER%/Scripts/activate && python --version

--- a/.ci/requirements_linux.txt
+++ b/.ci/requirements_linux.txt
@@ -1,4 +1,3 @@
 tox
 tox-venv
-virtualenv<=16.7.9  # TODO: Remove when dropping Python 2
 requests

--- a/tests/requirements_test.txt
+++ b/tests/requirements_test.txt
@@ -2,7 +2,6 @@ pytest>=3.6
 parameterized
 responses
 pluggy==0.11.0
-pylint==2.10.2; python_version >= '3.0'
-pylint==1.9.5; python_version == '2.7'
+pylint==2.10.2
 astroid
 spdx_lookup


### PR DESCRIPTION
Python 2 has been failing in the last week. Python 2 is deprecated. Hooks are _optional_ tools, if some of them don't work with Python 2 the user can always deactivate it.

Note.- This last error is probably related to new `wrapt` version: https://wrapt.readthedocs.io/en/latest/changes.html
