### PR TITLE
Skip OpenTelemetry Proto from hook 14

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -915,6 +915,7 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
             "wayland-protocols",
             "xorg-cf-files",
             "xorg-macros",
+            "opentelemetry-proto",
         ]:
             return
         if not _files_match_settings(conanfile, conanfile.package_folder, out):


### PR DESCRIPTION
Required by https://github.com/conan-io/conan-center-index/pull/7678 

That package does not contain source files, only .proto files.