### PR TITLE
Test for required_conan_version if strip_root is used KB-H065

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -728,7 +728,7 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
     @run_test("KB-H065", output)
     def test(out):
         def _find_required_conan_version(conanfile_content):
-            match = re.search(r"^\s*required_conan_version\s*=\s*\["']>=\s*([\d\.]+)\["']",
+            match = re.search(r"^\s*required_conan_version\s*=\s*\[\"']>=\s*([\d\.]+)\[\"']",
                               conanfile_content, re.MULTILINE)
             if match:
                 return tools.Version(match.group(1))

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -728,7 +728,7 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
     @run_test("KB-H065", output)
     def test(out):
         def _find_required_conan_version(conanfile_content):
-            match = re.search(r"^\s*required_conan_version\s*=\s*\">=\s*([\d\.]+)\"",
+            match = re.search(r"^\s*required_conan_version\s*=\s*\["']>=\s*([\d\.]+)\["']",
                               conanfile_content, re.MULTILINE)
             if match:
                 return tools.Version(match.group(1))

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -1165,3 +1165,71 @@ class ConanCenterTests(ConanClientTestCase):
                                                              "tools.cross_building(self.settings)"))
         output = self.conan(['export', 'conanfile.py', 'name/version@user/test'])
         self.assertIn("WARN: [TOOLS CROSS BUILDING (KB-H062)] The 'tools.cross_building(self.settings)' syntax in conanfile.py",output)
+
+    def test_strip_root_required_conan_version(self):
+        # no required_conan_version
+        conanfile = textwrap.dedent("""\
+        from conans import ConanFile, tools
+
+        class TestConan(ConanFile):
+            def source(self):
+                tools.get({}, strip_root=True)
+        """)
+        tools.save('conanfile.py', content=conanfile)
+        output = self.conan(['export', '.', 'name/all@user/test'])
+        self.assertIn("WARN: [NO REQUIRED_CONAN_VERSION (KB-H065)] tools.get", output)
+
+        # handle multiline call (for now only two lines)
+        conanfile = textwrap.dedent("""\
+               from conans import ConanFile, tools
+
+               class TestConan(ConanFile):
+                   def source(self):
+                       tools.get({}, 
+                                 strip_root=True)
+               """)
+        tools.save('conanfile.py', content=conanfile)
+        output = self.conan(['export', '.', 'name/version@user/test'])
+        self.assertIn("WARN: [NO REQUIRED_CONAN_VERSION (KB-H065)] tools.get", output)
+
+        # wrong required_conan_version
+        conanfile = textwrap.dedent("""\
+               from conans import ConanFile, tools
+
+               required_conan_version = ">=1.28.0"
+
+               class TestConan(ConanFile):
+                   def source(self):
+                       tools.get({}, strip_root=True)
+               """)
+        tools.save('conanfile.py', content=conanfile)
+        output = self.conan(['export', '.', 'name/version@user/test'])
+        self.assertIn("WARN: [NO REQUIRED_CONAN_VERSION (KB-H065)] tools.get", output)
+
+        # proper required_conan_version
+        conanfile = textwrap.dedent("""\
+                from conans import ConanFile, tools
+
+                required_conan_version = ">=1.33.0"
+
+                class TestConan(ConanFile):
+                    def source(self):
+                        tools.get({}, strip_root=True)
+                """)
+        tools.save('conanfile.py', content=conanfile)
+        output = self.conan(['export', '.', 'name/version@user/test'])
+        self.assertIn("[NO REQUIRED_CONAN_VERSION (KB-H065)] OK", output)
+
+        # short version, spacing
+        conanfile = textwrap.dedent("""\
+                from conans import ConanFile, tools
+
+                required_conan_version= ">= 1.33"
+
+                class TestConan(ConanFile):
+                    def source(self):
+                        tools.get({}, strip_root=True)
+                """)
+        tools.save('conanfile.py', content=conanfile)
+        output = self.conan(['export', '.', 'name/version@user/test'])
+        self.assertIn("[NO REQUIRED_CONAN_VERSION (KB-H065)] OK", output)


### PR DESCRIPTION
Recipes are upgraded to use `tools.get` with a [`strip_root=True`](https://docs.conan.io/en/latest/changelog.html#jan-2021). A directive `required_conan_version` can be missing. This hook checks it.

Proposed id: #KB-H065: NO REQUIRED_CONAN_VERSION