### PR TITLE
- [conan-center] skip hook messages for dependencies

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -864,6 +864,7 @@ def pre_build(output, conanfile, **kwargs):
 
 @raise_if_error_output
 def post_package(output, conanfile, conanfile_path, **kwargs):
+    this.reference = str(conanfile)
     @run_test("KB-H012", output)
     def test(out):
         if conanfile.version == "system":
@@ -987,7 +988,7 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
 
 @raise_if_error_output
 def post_package_info(output, conanfile, reference, **kwargs):
-    if str(reference) != this.reference:
+    if not hasattr(this, "reference") or str(reference) != this.reference:
         return
 
     @run_test("KB-H019", output)

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -4,6 +4,7 @@ import fnmatch
 import inspect
 import os
 import re
+import sys
 from logging import WARNING, ERROR, INFO, DEBUG, NOTSET
 
 import yaml
@@ -65,6 +66,8 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H064": "INVALID TOPICS",
              }
 
+
+this = sys.modules[__name__]
 
 class _HooksOutputErrorCollector(object):
 
@@ -156,6 +159,7 @@ def load_yml(path):
 
 @raise_if_error_output
 def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
+    this.reference = str(reference)
     conanfile_content = tools.load(conanfile_path)
     export_folder_path = os.path.dirname(conanfile_path)
     settings = _get_settings(conanfile)
@@ -983,6 +987,8 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
 
 @raise_if_error_output
 def post_package_info(output, conanfile, reference, **kwargs):
+    if str(reference) != this.reference:
+        return
 
     @run_test("KB-H019", output)
     def test(out):


### PR DESCRIPTION
it's pretty annoying that conan-center hook reports not only errors/warnings for the package being built/tested, but for all of its dependencies. they are obviously useless and uninteresting for the contributor.

it's mainly for the `post_package_info` hook right now, as other methods besides `package_info` (`export`, `source`, `build`, `package`) are only executed for the package being built/tested.

from the signature of the hook, there is no easy way to say if current conanfile/reference is the main one, or dependency:
```
def post_package_info(output, conanfile, reference, **kwargs):
```
there is nothing interesting in public `ConanFile` fields as well.

to complicate things, it seems like the hooks object is being re-created each time, so it's not trivial to save any state between method invocations, it's always brand new, constructed from scratch.

the reliable process-wide storage is `sys.modules`, which works well, regardless of how many times python file is loaded.