### PR TITLE
- [conan-center] improve KB-H019 output

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -989,13 +989,15 @@ def post_package_info(output, conanfile, reference, **kwargs):
         if conanfile.name in ["android-ndk", "cmake", "msys2", "strawberryperl"]:
             return
         bad_files = _get_files_following_patterns(conanfile.package_folder, ["*.cmake"])
-        build_dirs = [bd.replace("\\", "/") for bd in conanfile.cpp_info.builddirs]
+        build_dirs = {bd.replace("\\", "/") for bd in conanfile.cpp_info.build_paths}
         for component in conanfile.cpp_info.components.values():
-            build_dirs.extend([bd.replace("\\", "/") for bd in component.builddirs])
+            build_dirs.update({bd.replace("\\", "/") for bd in component.build_paths})
         files_missplaced = []
 
         for filename in bad_files:
             for bdir in build_dirs:
+                bdir = os.path.relpath(bdir, conanfile.package_folder)
+                bdir = "" if bdir == "." else bdir
                 bdir = "./{}".format(bdir)
                 # https://github.com/conan-io/conan/issues/5401
                 if bdir == "./":


### PR DESCRIPTION
closes: #345 

the current KB-H019 output is basically weird and useless
the clue is to use set and `build_paths` instead of `builddirs`

before:
```
[HOOK - conan-center.py] post_package_info(): WARN: [CMAKE FILE NOT IN BUILD FOLDERS (KB-H019)] The *.cmake files have to be placed in a folder declared as `cpp_info.builddirs`. Currently folders declared: ['', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '']
[HOOK - conan-center.py] post_package_info(): WARN: [CMAKE FILE NOT IN BUILD FOLDERS (KB-H019)] Found files: ./lib/cmake/conan-bugfix-global-target.cmake; ./lib/cmake/conan-magnum-al-info.cmake; ./lib/cmake/conan-magnum-distancefieldconverter.cmake; ./lib/cmake/conan-magnum-fontconverter.cmake; ./lib/cmake/conan-magnum-gl-info.cmake; ./lib/cmake/conan-magnum-imageconverter.cmake; ./lib/cmake/conan-magnum-sceneconverter.cmake; ./lib/cmake/conan-magnum-vars.cmake
```
after:
```
[HOOK - conan-center.py] post_package_info(): WARN: [CMAKE FILE NOT IN BUILD FOLDERS (KB-H019)] The *.cmake files have to be placed in a folder declared as `cpp_info.builddirs`. Currently folders declared: {'/Users/sse4/.conan/data/magnum/2020.06/_/_/package/0d351cde7814f54665d3eaf5b5eaa91c3b5a8876/'}
[HOOK - conan-center.py] post_package_info(): WARN: [CMAKE FILE NOT IN BUILD FOLDERS (KB-H019)] Found files: ./lib/cmake/conan-bugfix-global-target.cmake; ./lib/cmake/conan-magnum-al-info.cmake; ./lib/cmake/conan-magnum-distancefieldconverter.cmake; ./lib/cmake/conan-magnum-fontconverter.cmake; ./lib/cmake/conan-magnum-gl-info.cmake; ./lib/cmake/conan-magnum-imageconverter.cmake; ./lib/cmake/conan-magnum-sceneconverter.cmake; ./lib/cmake/conan-magnum-vars.cmake
```