### PR TITLE
Restrict tools.os_info usage

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -69,6 +69,7 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H062": "TOOLS CROSS BUILDING",
              "KB-H064": "INVALID TOPICS",
              "KB-H065": "NO REQUIRED_CONAN_VERSION",
+             "KB-H066": "NO OS_INFO",
              }
 
 
@@ -760,6 +761,14 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
             out.warn("tools.get with strip_root=True is available since Conan {0}. "
                      "Please add `required_conan_version >= \"{0}\"`"
                      "".format(str(required_version)))
+
+    @run_test("KB-H066", output)
+    def test(out):
+        for method in ["config_options", "configure"]:
+            method_obj = getattr(conanfile, method)
+            if "os_info." in inspect.getsource(method_obj):
+                out.error("tools.os_info must not be used in 'config_options' and 'configure'."
+                          " Replace by 'self.settings.os'.")
 
 
 @raise_if_error_output

--- a/tests/test_hooks/conan-center/test_tools_os_info.py
+++ b/tests/test_hooks/conan-center/test_tools_os_info.py
@@ -1,0 +1,51 @@
+import os
+import textwrap
+
+from conans import tools
+
+from tests.utils.test_cases.conan_client import ConanClientTestCase
+
+
+class ToolsOSInfoTest(ConanClientTestCase):
+    def _get_environ(self, **kwargs):
+        kwargs = super(ToolsOSInfoTest, self)._get_environ(**kwargs)
+        kwargs.update({'CONAN_HOOKS': os.path.join(os.path.dirname(__file__), '..', '..', '..',
+                                                   'hooks', 'conan-center')})
+        return kwargs
+
+    def test_config_options(self):
+        conanfile = textwrap.dedent("""\
+        from conans import ConanFile, tools
+        class AConan(ConanFile):
+            def config_options(self):
+                if tools.os_info.is_windows:
+                    pass
+        """)
+        tools.save('conanfile.py', content=conanfile)
+        output = self.conan(['export', '.', 'name/version@user/channel'])
+        self.assertIn("ERROR: [NO OS_INFO (KB-H066)]", output)
+
+    def test_configure(self):
+        conanfile = textwrap.dedent("""\
+        from conans import ConanFile, tools
+        class AConan(ConanFile):
+            def configure(self):
+                if tools.os_info.is_linux:
+                    pass
+        """)
+        tools.save('conanfile.py', content=conanfile)
+        output = self.conan(['export', '.', 'name/version@user/channel'])
+        self.assertIn("ERROR: [NO OS_INFO (KB-H066)]", output)
+
+    def test_import(self):
+        conanfile = textwrap.dedent("""\
+        from conans import ConanFile
+        from conans.tools import os_info
+        class AConan(ConanFile):
+            def configure(self):
+                if os_info.is_macos:
+                    pass
+        """)
+        tools.save('conanfile.py', content=conanfile)
+        output = self.conan(['export', '.', 'name/version@user/channel'])
+        self.assertIn("ERROR: [NO OS_INFO (KB-H066)]", output)


### PR DESCRIPTION
The `tools.os_info` is used only for specific cases on Conan Center Index:
- Packages related to Linux system packages
- `AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)`

https://docs.conan.io/en/latest/reference/conanfile/methods.html#system-requirements

This hook restricts its usage with `config_options` and `configure`. Maybe we could consider something more aggressive, like, only accepting `os_info` on `build` method and protected methods.

closes #373