### PR TITLE
Alert about windows short paths

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1024,9 +1024,9 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
     def test(out):
         conanfile_content = tools.load(conanfile_path)
         if not re.search(r"(\s{4}|\t)short_paths\s*=", conanfile_content):
-            # INFO: Need to reserve around 120 characters for package folder path
+            # INFO: Need to reserve around 160 characters for package folder path
             short_paths_name_length = 12
-            include_max_length_path = 120
+            include_max_length_path = 96
             if len(conanfile.name) >= short_paths_name_length:
                 out.warn(f"The package name '{conanfile.name}' is too long and may exceed Windows max path length. "
                           "Add 'short_paths = True' in your recipe.")

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1026,7 +1026,7 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
         if not re.search(r"(\s{4}|\t)short_paths\s*=", conanfile_content):
             windows_max_path = 256
             # INFO: Need to reserve around 160 characters for package folder path
-            for folder, length in [(conanfile.source_folder, 100), (conanfile.package_folder, 160)]:
+            for folder, length in [(conanfile.source_folder, 140), (conanfile.package_folder, 160)]:
                 file_max_length_path = windows_max_path - length
                 with tools.chdir(folder):
                     for (root, _, filenames) in os.walk("."):

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1027,14 +1027,15 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
             # INFO: Need to reserve around 160 characters for package folder path
             windows_max_path = 256
             file_max_length_path = windows_max_path - 160
-            with tools.chdir(conanfile.package_folder):
-                for (root, _, filenames) in os.walk("."):
-                    for filename in filenames:
-                        filepath = os.path.join(root, filename).replace("\\", "/")
-                        if len(filepath) >= file_max_length_path:
-                            out.warn(f"The file '{filepath}' has a very long path and may exceed Windows max path length. "
-                                     "Add 'short_paths = True' in your recipe.")
-                            break
+            for folder in [conanfile.source_folder, conanfile.package_folder]:
+                with tools.chdir(folder):
+                    for (root, _, filenames) in os.walk("."):
+                        for filename in filenames:
+                            filepath = os.path.join(root, filename).replace("\\", "/")
+                            if len(filepath) >= file_max_length_path:
+                                out.warn(f"The file '{filepath}' has a very long path and may exceed Windows max path length. "
+                                         "Add 'short_paths = True' in your recipe.")
+                                break
 
 
 @raise_if_error_output

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1024,10 +1024,10 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
     def test(out):
         conanfile_content = tools.load(conanfile_path)
         if not re.search(r"(\s{4}|\t)short_paths\s*=", conanfile_content):
-            # INFO: Need to reserve around 160 characters for package folder path
             windows_max_path = 256
-            file_max_length_path = windows_max_path - 160
-            for folder in [conanfile.source_folder, conanfile.package_folder]:
+            # INFO: Need to reserve around 160 characters for package folder path
+            for folder, length in [(conanfile.source_folder, 80), (conanfile.package_folder, 160)]:
+                file_max_length_path = windows_max_path - length
                 with tools.chdir(folder):
                     for (root, _, filenames) in os.walk("."):
                         for filename in filenames:

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1026,7 +1026,7 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
         if not re.search(r"(\s{4}|\t)short_paths\s*=", conanfile_content):
             windows_max_path = 256
             # INFO: Need to reserve around 160 characters for package folder path
-            for folder, length in [(conanfile.source_folder, 80), (conanfile.package_folder, 160)]:
+            for folder, length in [(conanfile.source_folder, 100), (conanfile.package_folder, 160)]:
                 file_max_length_path = windows_max_path - length
                 with tools.chdir(folder):
                     for (root, _, filenames) in os.walk("."):

--- a/tests/test_hooks/conan-center/test_short_paths.py
+++ b/tests/test_hooks/conan-center/test_short_paths.py
@@ -1,6 +1,5 @@
 import os
 import textwrap
-import tempfile
 
 from conans import tools
 
@@ -26,11 +25,9 @@ class ShortPathsTests(ConanClientTestCase):
             """)
 
     def _get_environ(self, **kwargs):
-        dirpath = tempfile.mkdtemp()
         kwargs = super(ShortPathsTests, self)._get_environ(**kwargs)
         kwargs.update({'CONAN_HOOKS': os.path.join(os.path.dirname(__file__), '..', '..', '..',
-                                                   'hooks', 'conan-center'),
-                       'CONAN_USER_HOME_SHORT': dirpath})
+                                                   'hooks', 'conan-center')})
         return kwargs
 
     def test_not_needed_short_path(self):

--- a/tests/test_hooks/conan-center/test_short_paths.py
+++ b/tests/test_hooks/conan-center/test_short_paths.py
@@ -30,7 +30,7 @@ class ShortPathsTests(ConanClientTestCase):
                         class AConan(ConanFile):
                             # short_paths = True
                             def source(self):
-                                includedir = os.path.join(self.source_folder, "include", "another-include-folder", "another-subfolder", "very-very-very-long-folder-subfolder-another-folder", "another-include-include-include-folder")
+                                includedir = os.path.join(self.source_folder, "include", "another-include-folder", "another-subfolder", "very-very-very-long-folder-subfolder-another-folder")
                                 tools.mkdir(includedir)
                                 tools.save(os.path.join(includedir, "a-very-very-very-long-header-file-which-may-trigger-hook-66.h"), "")
                         """)
@@ -65,7 +65,7 @@ class ShortPathsTests(ConanClientTestCase):
         output = self.conan(['create', '.', 'name/version@user/channel'])
         self.assertIn(
             "WARN: [SHORT_PATHS USAGE (KB-H066)] The file './include/another-include-folder/another-subfolder/very-very-very-long-folder-subfolder-another-folder/"
-            "another-include-include-include-folder/a-very-very-very-long-header-file-which-may-trigger-hook-66.h'"
+            "a-very-very-very-long-header-file-which-may-trigger-hook-66.h'"
             " has a very long path and may exceed Windows max path length. Add 'short_paths = True' in your "
             "recipe.", output)
 

--- a/tests/test_hooks/conan-center/test_short_paths.py
+++ b/tests/test_hooks/conan-center/test_short_paths.py
@@ -1,5 +1,6 @@
 import os
 import textwrap
+import tempfile
 
 from conans import tools
 
@@ -25,9 +26,11 @@ class ShortPathsTests(ConanClientTestCase):
             """)
 
     def _get_environ(self, **kwargs):
+        dirpath = tempfile.mkdtemp()
         kwargs = super(ShortPathsTests, self)._get_environ(**kwargs)
         kwargs.update({'CONAN_HOOKS': os.path.join(os.path.dirname(__file__), '..', '..', '..',
-                                                   'hooks', 'conan-center')})
+                                                   'hooks', 'conan-center'),
+                       'CONAN_USER_HOME_SHORT': dirpath})
         return kwargs
 
     def test_not_needed_short_path(self):

--- a/tests/test_hooks/conan-center/test_short_paths.py
+++ b/tests/test_hooks/conan-center/test_short_paths.py
@@ -36,23 +36,10 @@ class ShortPathsTests(ConanClientTestCase):
         self.assertNotIn("WARN: [SHORT_PATHS USAGE (KB-H066)]", output)
         self.assertIn("[SHORT_PATHS USAGE (KB-H066)] OK", output)
 
-    def test_long_package_name(self):
-        tools.save('conanfile.py', content=self.conanfile)
-        output = self.conan(['create', '.', 'a-very-very-long-package-name/version@user/channel'])
-        self.assertIn("WARN: [SHORT_PATHS USAGE (KB-H066)] The package name 'a-very-very-long-package-name' "
-                      "is too long and may exceed Windows max path length. Add 'short_paths = True' in your recipe.",
-                      output)
-
-    def test_long_package_name_with_short_paths(self):
-        tools.save('conanfile.py', content=self.conanfile.replace("pass", "short_paths = True"))
-        output = self.conan(['create', '.', 'a-very-very-long-package-name/version@user/channel'])
-        self.assertNotIn("WARN: [SHORT_PATHS USAGE (KB-H066)]", output)
-        self.assertIn("[SHORT_PATHS USAGE (KB-H066)] OK", output)
-
     def test_include_folder(self):
         tools.save('conanfile.py', content=self.conanfile_long)
         output = self.conan(['create', '.', 'name/version@user/channel'])
-        self.assertIn("WARN: [SHORT_PATHS USAGE (KB-H066)] The header file './include/another-include-folder/another-subfolder/a-very-very-very-long-header-file-which-may-trigger-hook-66.h'"
+        self.assertIn("WARN: [SHORT_PATHS USAGE (KB-H066)] The file './include/another-include-folder/another-subfolder/a-very-very-very-long-header-file-which-may-trigger-hook-66.h'"
                       " has a very long path and may exceed Windows max path length. Add 'short_paths = True' in your "
                       "recipe.", output)
 
@@ -60,18 +47,4 @@ class ShortPathsTests(ConanClientTestCase):
         tools.save('conanfile.py', content=self.conanfile_long.replace("# s", "s"))
         output = self.conan(['create', '.', 'name/version@user/channel'])
         self.assertNotIn("WARN: [SHORT_PATHS USAGE (KB-H066)]", output)
-
-    def test_both_long_name_and_path(self):
-        tools.save('conanfile.py', content=self.conanfile_long)
-        output = self.conan(['create', '.', 'a-very-very-long-package-name/version@user/channel'])
-        self.assertIn("WARN: [SHORT_PATHS USAGE (KB-H066)] The package name 'a-very-very-long-package-name' "
-                      "is too long and may exceed Windows max path length. Add 'short_paths = True' in your recipe.",
-                      output)
-        self.assertIn("WARN: [SHORT_PATHS USAGE (KB-H066)] The header file './include/another-include-folder/another-subfolder/a-very-very-very-long-header-file-which-may-trigger-hook-66.h'"
-                      " has a very long path and may exceed Windows max path length. Add 'short_paths = True' in your "
-                      "recipe.", output)
-
-    def test_both_long_name_and_path_with_shorts_path(self):
-        tools.save('conanfile.py', content=self.conanfile_long.replace("# s", "s"))
-        output = self.conan(['create', '.', 'a-very-very-long-package-name/version@user/channel'])
-        self.assertNotIn("WARN: [SHORT_PATHS USAGE (KB-H066)]", output)
+        self.assertIn("[SHORT_PATHS USAGE (KB-H066)] OK", output)

--- a/tests/test_hooks/conan-center/test_short_paths.py
+++ b/tests/test_hooks/conan-center/test_short_paths.py
@@ -8,10 +8,10 @@ from tests.utils.test_cases.conan_client import ConanClientTestCase
 
 class ShortPathsTests(ConanClientTestCase):
     conanfile = textwrap.dedent("""\
-        from conans import ConanFile
-        class AConan(ConanFile):
-            pass
-        """)
+            from conans import ConanFile
+            class AConan(ConanFile):
+                pass
+            """)
 
     conanfile_long = textwrap.dedent("""\
             from conans import ConanFile, tools
@@ -25,15 +25,16 @@ class ShortPathsTests(ConanClientTestCase):
             """)
 
     conanfile_source = textwrap.dedent("""\
-                        from conans import ConanFile, tools
-                        import os
-                        class AConan(ConanFile):
-                            # short_paths = True
-                            def source(self):
-                                includedir = os.path.join(self.source_folder, "include", "another-include-folder", "another-subfolder", "very-very-very-long-folder-subfolder")
-                                tools.mkdir(includedir)
-                                tools.save(os.path.join(includedir, "a-very-very-very-long-header-file-which-may-trigger-hook-66.h"), "")
-                        """)
+            from conans import ConanFile, tools
+            import os
+            class AConan(ConanFile):
+                no_copy_source = True
+                # short_paths = True
+                def source(self):
+                    includedir = os.path.join(self.source_folder, "include", "another-include-folder", "another-subfolder", "very-very-very-long-folder-subfolder"  )
+                    tools.mkdir(includedir)
+                    tools.save(os.path.join(includedir, "a-very-very-very-long-header-file-which-may-trigger-hook-66.h"), "")
+            """)
 
     def _get_environ(self, **kwargs):
         kwargs = super(ShortPathsTests, self)._get_environ(**kwargs)

--- a/tests/test_hooks/conan-center/test_short_paths.py
+++ b/tests/test_hooks/conan-center/test_short_paths.py
@@ -19,7 +19,7 @@ class ShortPathsTests(ConanClientTestCase):
             class AConan(ConanFile):
                 # short_paths = True
                 def package(self):
-                    includedir = os.path.join(self.package_folder, "include", "another-include-folder", "subdir", "another", "include", "folde", "another-one")
+                    includedir = os.path.join(self.package_folder, "include", "another-include-folder", "another-subfolder")
                     tools.mkdir(includedir)
                     tools.save(os.path.join(includedir, "a-very-very-very-long-header-file-which-may-trigger-hook-66.h"), "")
             """)
@@ -52,8 +52,7 @@ class ShortPathsTests(ConanClientTestCase):
     def test_include_folder(self):
         tools.save('conanfile.py', content=self.conanfile_long)
         output = self.conan(['create', '.', 'name/version@user/channel'])
-        self.assertIn("WARN: [SHORT_PATHS USAGE (KB-H066)] The header file './include/another-include-folder/subdir/"
-                      "another/include/folde/another-one/a-very-very-very-long-header-file-which-may-trigger-hook-66.h'"
+        self.assertIn("WARN: [SHORT_PATHS USAGE (KB-H066)] The header file './include/another-include-folder/another-subfolder/a-very-very-very-long-header-file-which-may-trigger-hook-66.h'"
                       " has a very long path and may exceed Windows max path length. Add 'short_paths = True' in your "
                       "recipe.", output)
 
@@ -68,8 +67,7 @@ class ShortPathsTests(ConanClientTestCase):
         self.assertIn("WARN: [SHORT_PATHS USAGE (KB-H066)] The package name 'a-very-very-long-package-name' "
                       "is too long and may exceed Windows max path length. Add 'short_paths = True' in your recipe.",
                       output)
-        self.assertIn("WARN: [SHORT_PATHS USAGE (KB-H066)] The header file './include/another-include-folder/subdir/"
-                      "another/include/folde/another-one/a-very-very-very-long-header-file-which-may-trigger-hook-66.h'"
+        self.assertIn("WARN: [SHORT_PATHS USAGE (KB-H066)] The header file './include/another-include-folder/another-subfolder/a-very-very-very-long-header-file-which-may-trigger-hook-66.h'"
                       " has a very long path and may exceed Windows max path length. Add 'short_paths = True' in your "
                       "recipe.", output)
 

--- a/tests/test_hooks/conan-center/test_short_paths.py
+++ b/tests/test_hooks/conan-center/test_short_paths.py
@@ -24,6 +24,17 @@ class ShortPathsTests(ConanClientTestCase):
                     tools.save(os.path.join(includedir, "a-very-very-very-long-header-file-which-may-trigger-hook-66.h"), "")
             """)
 
+    conanfile_source = textwrap.dedent("""\
+                        from conans import ConanFile, tools
+                        import os
+                        class AConan(ConanFile):
+                            # short_paths = True
+                            def source(self):
+                                includedir = os.path.join(self.source_folder, "include", "another-include-folder", "another-subfolder")
+                                tools.mkdir(includedir)
+                                tools.save(os.path.join(includedir, "a-very-very-very-long-header-file-which-may-trigger-hook-66.h"), "")
+                        """)
+
     def _get_environ(self, **kwargs):
         kwargs = super(ShortPathsTests, self)._get_environ(**kwargs)
         kwargs.update({'CONAN_HOOKS': os.path.join(os.path.dirname(__file__), '..', '..', '..',
@@ -45,6 +56,20 @@ class ShortPathsTests(ConanClientTestCase):
 
     def test_include_folder_short_paths(self):
         tools.save('conanfile.py', content=self.conanfile_long.replace("# s", "s"))
+        output = self.conan(['create', '.', 'name/version@user/channel'])
+        self.assertNotIn("WARN: [SHORT_PATHS USAGE (KB-H066)]", output)
+        self.assertIn("[SHORT_PATHS USAGE (KB-H066)] OK", output)
+
+    def test_source_folder_long_path(self):
+        tools.save('conanfile.py', content=self.conanfile_source)
+        output = self.conan(['create', '.', 'name/version@user/channel'])
+        self.assertIn(
+            "WARN: [SHORT_PATHS USAGE (KB-H066)] The file './include/another-include-folder/another-subfolder/a-very-very-very-long-header-file-which-may-trigger-hook-66.h'"
+            " has a very long path and may exceed Windows max path length. Add 'short_paths = True' in your "
+            "recipe.", output)
+
+    def test_source_folder_short_path(self):
+        tools.save('conanfile.py', content=self.conanfile_source.replace("# s", "s"))
         output = self.conan(['create', '.', 'name/version@user/channel'])
         self.assertNotIn("WARN: [SHORT_PATHS USAGE (KB-H066)]", output)
         self.assertIn("[SHORT_PATHS USAGE (KB-H066)] OK", output)

--- a/tests/test_hooks/conan-center/test_short_paths.py
+++ b/tests/test_hooks/conan-center/test_short_paths.py
@@ -1,0 +1,79 @@
+import os
+import textwrap
+
+from conans import tools
+
+from tests.utils.test_cases.conan_client import ConanClientTestCase
+
+
+class ShortPathsTests(ConanClientTestCase):
+    conanfile = textwrap.dedent("""\
+        from conans import ConanFile
+        class AConan(ConanFile):
+            pass
+        """)
+
+    conanfile_long = textwrap.dedent("""\
+            from conans import ConanFile, tools
+            import os
+            class AConan(ConanFile):
+                # short_paths = True
+                def package(self):
+                    includedir = os.path.join(self.package_folder, "include", "another-include-folder", "subdir", "another", "include", "folde", "another-one")
+                    tools.mkdir(includedir)
+                    tools.save(os.path.join(includedir, "a-very-very-very-long-header-file-which-may-trigger-hook-66.h"), "")
+            """)
+
+    def _get_environ(self, **kwargs):
+        kwargs = super(ShortPathsTests, self)._get_environ(**kwargs)
+        kwargs.update({'CONAN_HOOKS': os.path.join(os.path.dirname(__file__), '..', '..', '..',
+                                                   'hooks', 'conan-center')})
+        return kwargs
+
+    def test_not_needed_short_path(self):
+        tools.save('conanfile.py', content=self.conanfile)
+        output = self.conan(['create', '.', 'name/version@user/channel'])
+        self.assertNotIn("WARN: [SHORT_PATHS USAGE (KB-H066)]", output)
+        self.assertIn("[SHORT_PATHS USAGE (KB-H066)] OK", output)
+
+    def test_long_package_name(self):
+        tools.save('conanfile.py', content=self.conanfile)
+        output = self.conan(['create', '.', 'a-very-very-long-package-name/version@user/channel'])
+        self.assertIn("WARN: [SHORT_PATHS USAGE (KB-H066)] The package name 'a-very-very-long-package-name' "
+                      "is too long and may exceed Windows max path length. Add 'short_paths = True' in your recipe.",
+                      output)
+
+    def test_long_package_name_with_short_paths(self):
+        tools.save('conanfile.py', content=self.conanfile.replace("pass", "short_paths = True"))
+        output = self.conan(['create', '.', 'a-very-very-long-package-name/version@user/channel'])
+        self.assertNotIn("WARN: [SHORT_PATHS USAGE (KB-H066)]", output)
+        self.assertIn("[SHORT_PATHS USAGE (KB-H066)] OK", output)
+
+    def test_include_folder(self):
+        tools.save('conanfile.py', content=self.conanfile_long)
+        output = self.conan(['create', '.', 'name/version@user/channel'])
+        self.assertIn("WARN: [SHORT_PATHS USAGE (KB-H066)] The header file './include/another-include-folder/subdir/"
+                      "another/include/folde/another-one/a-very-very-very-long-header-file-which-may-trigger-hook-66.h'"
+                      " has a very long path and may exceed Windows max path length. Add 'short_paths = True' in your "
+                      "recipe.", output)
+
+    def test_include_folder_short_paths(self):
+        tools.save('conanfile.py', content=self.conanfile_long.replace("# s", "s"))
+        output = self.conan(['create', '.', 'name/version@user/channel'])
+        self.assertNotIn("WARN: [SHORT_PATHS USAGE (KB-H066)]", output)
+
+    def test_both_long_name_and_path(self):
+        tools.save('conanfile.py', content=self.conanfile_long)
+        output = self.conan(['create', '.', 'a-very-very-long-package-name/version@user/channel'])
+        self.assertIn("WARN: [SHORT_PATHS USAGE (KB-H066)] The package name 'a-very-very-long-package-name' "
+                      "is too long and may exceed Windows max path length. Add 'short_paths = True' in your recipe.",
+                      output)
+        self.assertIn("WARN: [SHORT_PATHS USAGE (KB-H066)] The header file './include/another-include-folder/subdir/"
+                      "another/include/folde/another-one/a-very-very-very-long-header-file-which-may-trigger-hook-66.h'"
+                      " has a very long path and may exceed Windows max path length. Add 'short_paths = True' in your "
+                      "recipe.", output)
+
+    def test_both_long_name_and_path_with_shorts_path(self):
+        tools.save('conanfile.py', content=self.conanfile_long.replace("# s", "s"))
+        output = self.conan(['create', '.', 'a-very-very-long-package-name/version@user/channel'])
+        self.assertNotIn("WARN: [SHORT_PATHS USAGE (KB-H066)]", output)

--- a/tests/test_hooks/conan-center/test_short_paths.py
+++ b/tests/test_hooks/conan-center/test_short_paths.py
@@ -30,7 +30,7 @@ class ShortPathsTests(ConanClientTestCase):
                         class AConan(ConanFile):
                             # short_paths = True
                             def source(self):
-                                includedir = os.path.join(self.source_folder, "include", "another-include-folder", "another-subfolder")
+                                includedir = os.path.join(self.source_folder, "include", "another-include-folder", "another-subfolder", "very-very-very-long-folder-subfolder-another-folder", "another-include-include-include-folder")
                                 tools.mkdir(includedir)
                                 tools.save(os.path.join(includedir, "a-very-very-very-long-header-file-which-may-trigger-hook-66.h"), "")
                         """)
@@ -64,7 +64,8 @@ class ShortPathsTests(ConanClientTestCase):
         tools.save('conanfile.py', content=self.conanfile_source)
         output = self.conan(['create', '.', 'name/version@user/channel'])
         self.assertIn(
-            "WARN: [SHORT_PATHS USAGE (KB-H066)] The file './include/another-include-folder/another-subfolder/a-very-very-very-long-header-file-which-may-trigger-hook-66.h'"
+            "WARN: [SHORT_PATHS USAGE (KB-H066)] The file './include/another-include-folder/another-subfolder/very-very-very-long-folder-subfolder-another-folder/"
+            "another-include-include-include-folder/a-very-very-very-long-header-file-which-may-trigger-hook-66.h'"
             " has a very long path and may exceed Windows max path length. Add 'short_paths = True' in your "
             "recipe.", output)
 

--- a/tests/test_hooks/conan-center/test_short_paths.py
+++ b/tests/test_hooks/conan-center/test_short_paths.py
@@ -30,7 +30,7 @@ class ShortPathsTests(ConanClientTestCase):
                         class AConan(ConanFile):
                             # short_paths = True
                             def source(self):
-                                includedir = os.path.join(self.source_folder, "include", "another-include-folder", "another-subfolder", "very-very-very-long-folder-subfolder-another-folder")
+                                includedir = os.path.join(self.source_folder, "include", "another-include-folder", "another-subfolder", "very-very-very-long-folder-subfolder")
                                 tools.mkdir(includedir)
                                 tools.save(os.path.join(includedir, "a-very-very-very-long-header-file-which-may-trigger-hook-66.h"), "")
                         """)
@@ -64,7 +64,7 @@ class ShortPathsTests(ConanClientTestCase):
         tools.save('conanfile.py', content=self.conanfile_source)
         output = self.conan(['create', '.', 'name/version@user/channel'])
         self.assertIn(
-            "WARN: [SHORT_PATHS USAGE (KB-H066)] The file './include/another-include-folder/another-subfolder/very-very-very-long-folder-subfolder-another-folder/"
+            "WARN: [SHORT_PATHS USAGE (KB-H066)] The file './include/another-include-folder/another-subfolder/very-very-very-long-folder-subfolder/"
             "a-very-very-very-long-header-file-which-may-trigger-hook-66.h'"
             " has a very long path and may exceed Windows max path length. Add 'short_paths = True' in your "
             "recipe.", output)

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ setenv =
     coverage: COVERAGE_FILE={toxinidir}/.coverage
     coverage: PYTESTDJANGO_COVERAGE_SRC={toxinidir}/
 
-passenv = PYTEST_ADDOPTS USE_UNSUPPORTED_CONAN_WITH_PYTHON_2
+passenv = PYTEST_ADDOPTS USE_UNSUPPORTED_CONAN_WITH_PYTHON_2 USERNAME
 
 commands =
     python --version


### PR DESCRIPTION
- We have to consider around 160 characters for Conan folder structure, e.g `C:\Users\foo\.conan\data\nlohmann_json\3.9.1\authorname\testing\package\5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9\include`

closes #362 