### PR TITLE
Fix false positives for required_conan_version, KB-H065

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -744,7 +744,7 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
     @run_test("KB-H065", output)
     def test(out):
         def _find_required_conan_version(conanfile_content):
-            match = re.search(r"^\s*required_conan_version\s*=\s*\[\"']>=\s*([\d\.]+)\[\"']",
+            match = re.search(r"^\s*required_conan_version\s*=\s*[\"']>=\s*([\d\.]+)[\"']",
                               conanfile_content, re.MULTILINE)
             if match:
                 return tools.Version(match.group(1))

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -1170,7 +1170,7 @@ class ConanCenterTests(ConanClientTestCase):
                 """)
         tools.save('conanfile.py', content=conanfile)
         output = self.conan(['export', '.', 'name/version@user/test'])
-        self.assertIn("[NO REQUIRED_CONAN_VERSION (KB-H065)] OK", output)
+        self.assertNotIn("[NO REQUIRED_CONAN_VERSION (KB-H065)] tools.get", output)
 
         # short version, spacing
         conanfile = textwrap.dedent("""\
@@ -1184,7 +1184,8 @@ class ConanCenterTests(ConanClientTestCase):
                 """)
         tools.save('conanfile.py', content=conanfile)
         output = self.conan(['export', '.', 'name/version@user/test'])
-        self.assertIn("[NO REQUIRED_CONAN_VERSION (KB-H065)] OK", output)
+        self.assertNotIn("[NO REQUIRED_CONAN_VERSION (KB-H065)] tools.get", output)
+
 
     def test_no_collect_libs_warning(self):
         conanfile = textwrap.dedent("""\

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -1186,6 +1186,20 @@ class ConanCenterTests(ConanClientTestCase):
         output = self.conan(['export', '.', 'name/version@user/test'])
         self.assertNotIn("[NO REQUIRED_CONAN_VERSION (KB-H065)] tools.get", output)
 
+        # single quotes
+        conanfile = textwrap.dedent("""\
+                from conans import ConanFile, tools
+
+                required_conan_version = '>=1.33.0'
+
+                class TestConan(ConanFile):
+                    def source(self):
+                        tools.get({}, strip_root=True)
+                """)
+        tools.save('conanfile.py', content=conanfile)
+        output = self.conan(['export', '.', 'name/version@user/test'])
+        self.assertNotIn("[NO REQUIRED_CONAN_VERSION (KB-H065)] tools.get", output)
+
 
     def test_no_collect_libs_warning(self):
         conanfile = textwrap.dedent("""\


### PR DESCRIPTION
It is a fixup to PR #368 , can block hook usage. The test for passing hook check was incorrectly written so it cannot detect an error in regex. Hook raises false positives to completely valid `required_conan_version = ">=1.33.0"`.