### PR TITLE
[conan-center] KB-H069 default_options is not allow on test_package

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -73,6 +73,7 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H065": "NO REQUIRED_CONAN_VERSION",
              "KB-H066": "SHORT_PATHS USAGE",
              "KB-H068": "TEST_TYPE MANAGEMENT",
+             "KB-H069": "TEST PACKAGE - NO DEFAULT OPTIONS",
              }
 
 
@@ -771,11 +772,22 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
         test_package_path = os.path.join(os.path.dirname(conanfile_path), "test_package", "conanfile.py")
         if os.path.isfile(test_package_path):
             try:
-                python_requires = ConanPythonRequire(None, None)
-                _, test_conanfile = parse_conanfile(test_package_path, python_requires=python_requires, generator_manager=None)
+                test_conanfile = _load_conanfile(test_package_path)
                 test_type = getattr(test_conanfile, "test_type", None)
                 if test_type and test_type != "explicit":
                     out.error(f"The attribute 'test_type' only should be used with 'explicit' value.: {test_type}")
+            except Exception as e:
+                out.warn("Invalid conanfile: {}".format(e))
+
+    @run_test("KB-H069", output)
+    def test(out):
+        test_package_path = os.path.join(os.path.dirname(conanfile_path), "test_package", "conanfile.py")
+        if os.path.isfile(test_package_path):
+            try:
+                test_conanfile = _load_conanfile(test_package_path)
+                default_options = getattr(test_conanfile, "default_options", None)
+                if default_options:
+                    out.error(f"The attribute 'default_options' is not allowed on test_package/conanfile.py, remove it.")
             except Exception as e:
                 out.warn("Invalid conanfile: {}".format(e))
 
@@ -1242,3 +1254,11 @@ def _check_short_paths(conanfile_path, folder_path, max_length_path, output):
                             f"The file '{filepath}' has a very long path and may exceed Windows max path length. "
                             "Add 'short_paths = True' in your recipe.")
                         break
+
+
+def _load_conanfile(conanfile_path):
+    python_requires = ConanPythonRequire(None, None)
+    _, conanfile_obj = parse_conanfile(conanfile_path,
+                                       python_requires=python_requires,
+                                       generator_manager=None)
+    return conanfile_obj

--- a/tests/test_hooks/conan-center/test_no_default_options.py
+++ b/tests/test_hooks/conan-center/test_no_default_options.py
@@ -1,0 +1,37 @@
+import os
+import textwrap
+
+from conans import tools
+
+from tests.utils.test_cases.conan_client import ConanClientTestCase
+
+
+class NoDefaultOptionsTests(ConanClientTestCase):
+    conanfile = textwrap.dedent("""\
+        import os
+        from conans import ConanFile, tools
+
+        class AConan(ConanFile):
+            {}
+        """)
+
+    def _get_environ(self, **kwargs):
+        kwargs = super(NoDefaultOptionsTests, self)._get_environ(**kwargs)
+        kwargs.update({'CONAN_HOOKS': os.path.join(os.path.dirname(__file__), '..', '..', '..',
+                                                   'hooks', 'conan-center')})
+        return kwargs
+
+    def test_no_default_options(self):
+        tools.save('conanfile.py', content=self.conanfile.replace("{}", "pass"))
+        tools.save('test_package/conanfile.py', content=self.conanfile.replace("{}", "pass"))
+        output = self.conan(['export', '.', 'name/version@user/channel'])
+        self.assertIn("[TEST PACKAGE - NO DEFAULT OPTIONS (KB-H069)]", output)
+
+    def test_with_default_options(self):
+        tools.save('conanfile.py', content=self.conanfile.replace("{}", "pass"))
+        tools.save('test_package/conanfile.py',
+                   content=self.conanfile.replace("{}", "default_options = {'name:foo': True}"))
+        output = self.conan(['export', '.', 'name/version@user/channel'])
+        self.assertIn("ERROR: [TEST PACKAGE - NO DEFAULT OPTIONS (KB-H069)] The attribute"
+                      " 'default_options' is not allowed on test_package/conanfile.py, remove it.",
+                      output)

--- a/tests/test_hooks/test_recipe_linter.py
+++ b/tests/test_hooks/test_recipe_linter.py
@@ -17,7 +17,7 @@ from tests.utils.test_cases.conan_client import ConanClientTestCase
 
 class RecipeLinterTests(ConanClientTestCase):
     conanfile = textwrap.dedent(r"""
-        from conans import ConanFile, tools
+        from conan import ConanFile, tools
         
         class TestConan(ConanFile):
             name = "name"
@@ -65,7 +65,7 @@ class RecipeLinterTests(ConanClientTestCase):
 
     def test_path_with_spaces(self):
         conanfile = textwrap.dedent(r"""
-            from conans import ConanFile
+            from conan import ConanFile
 
             class Recipe(ConanFile):
                 def build(self):
@@ -88,7 +88,7 @@ class RecipeLinterTests(ConanClientTestCase):
 
     def test_custom_plugin(self):
         conanfile = textwrap.dedent(r"""
-            from conans import ConanFile
+            from conan import ConanFile
 
             class Recipe(ConanFile):
                 def build(self):
@@ -111,7 +111,7 @@ class RecipeLinterTests(ConanClientTestCase):
 
     def test_dynamic_fields(self):
         conanfile = textwrap.dedent("""
-            from conans import ConanFile
+            from conan import ConanFile
             
             class TestConan(ConanFile):
                 name = "consumer"
@@ -150,7 +150,7 @@ class RecipeLinterTests(ConanClientTestCase):
 
     def test_catch_them_all(self):
         conanfile = textwrap.dedent("""
-            from conans import ConanFile
+            from conan import ConanFile
             class BaseConan(ConanFile):
 
                 def source(self):
@@ -173,7 +173,7 @@ class RecipeLinterTests(ConanClientTestCase):
 
     def test_conan_data(self):
         conanfile = textwrap.dedent("""
-            from conans import ConanFile
+            from conan import ConanFile
         
             class ExampleConan(ConanFile):
     
@@ -191,7 +191,9 @@ class RecipeLinterTests(ConanClientTestCase):
     def test_python_requires(self):
         """ python_requires were not added to the 'pylint_plugin' until 1.21 """
         conanfile = textwrap.dedent("""
-            from conans import ConanFile, python_requires
+            from conan import ConanFile
+            # pylint: disable=E9000
+            from conans import python_requires 
 
             base = python_requires("name/version")
 

--- a/tests/test_hooks/test_recipe_linter.py
+++ b/tests/test_hooks/test_recipe_linter.py
@@ -190,19 +190,23 @@ class RecipeLinterTests(ConanClientTestCase):
     @unittest.skipUnless(version.parse(conan_version) >= version.parse("1.21.0"), "Need python_version")
     def test_python_requires(self):
         """ python_requires were not added to the 'pylint_plugin' until 1.21 """
+        pytreq_conanfile = textwrap.dedent("""
+            from conan import ConanFile
+            class TestConan(ConanFile):
+                pass
+            """)
+        tools.save('pyrequire.py', pytreq_conanfile)
+        self.conan(['export', 'pyrequire.py', 'package/version@user/channel'])
         conanfile = textwrap.dedent("""
             from conan import ConanFile
-            # pylint: disable=E9000
-            from conans import python_requires 
-
-            base = python_requires("name/version")
 
             class TestConan(ConanFile):
                 name = "consumer"
                 version = "version"
+                python_requires = "package/version@user/channel"
             """)
-        tools.save('require.py', self.conanfile)
-        self.conan(['export', 'require.py', 'name/version@'])
+        tools.save('require.py', conanfile)
+        self.conan(['export', 'require.py', 'consumer/version@'])
 
         tools.save('consumer.py', content=conanfile)
         with environment_append({"CONAN_PYLINT_WERR": "1"}):

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skipsdist=True
 envlist =
-    py{36,37,38}-conan{dev,current,prev,prevprev}
+    py{36,37,38,310}-conan{dev,current,prev,prevprev}
 
 [testenv]
 deps =


### PR DESCRIPTION
Test package should not use default options, otherwise, it won't test the default package configuration.

closes #287

Wiki: 

#### **<a name="KB-H069">#KB-H069</a>: "TEST PACKAGE - NO DEFAULT OPTIONS"**

When testing the built package, we need to validate the default configuration, including its options. in case of use
custom options via `default_options`, this will not guarantee the default package state. 
