### PR TITLE
[conan-center] KB-H040 Do not allow cpp_info.filename usage

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -447,16 +447,17 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
 
     @run_test("KB-H040", output)
     def test(out):
-        if "self.cpp_info.name =" in conanfile_content:
-            out.error("CCI uses the name of the package for cmake generator."
-                      " Use 'cpp_info.names' instead.")
+        match = re.search(r"self\.cpp_info\.(name|filename)\s?=", conanfile_content)
+        if match:
+            out.error("CCI uses the name of the package for cmake generator and filename by default."
+                      " Replace 'cpp_info.{0}' by 'cpp_info.{0}s[<generator>]'.".format(match.group(1)))
 
-        for generator in ["cmake", "cmake_multi"]:
-            if "self.cpp_info.names['{}']".format(generator) in conanfile_content or \
-               'self.cpp_info.names["{}"]'.format(generator) in conanfile_content:
-                out.error("CCI uses the name of the package for {0} generator. "
-                          "Conanfile should not contain 'self.cpp_info.names['{0}']'. "
-                          " Use 'cmake_find_package' and 'cmake_find_package_multi' instead.".format(generator))
+        match = re.search(r"self\.cpp_info\.(names|filenames)\[\s?['\"](cmake|cmake_multi)['\"]\s?\]", conanfile_content)
+        if match:
+            out.error("CCI uses the name of the package for {0} generator. "
+                      "Conanfile should not contain 'self.cpp_info.{1}['{0}']'. "
+                      "Use 'cmake_find_package' and 'cmake_find_package_multi' instead.".format(match.group(2),
+                                                                                                 match.group(1)))
 
     @run_test("KB-H041", output)
     def test(out):

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -719,41 +719,6 @@ class ConanCenterTests(ConanClientTestCase):
         output = self.conan(['export', '.', 'name/version@user/test'], expected_return_code=ERROR_GENERAL)
         self.assertIn("ERROR: [NOT ALLOWED ATTRIBUTES (KB-H039)] Conanfile should not contain attributes: 'scm'", output)
 
-    @pytest.mark.skipif(Version(conan_version) < "1.21", reason="requires Conan 1.21 or higher")
-    def test_no_target_name(self):
-        conanfile = textwrap.dedent("""\
-        from conans import ConanFile
-        class AConan(ConanFile):
-            def package_info(self):
-                {}
-
-        """)
-        pkg_config = 'self.cpp_info.names["pkg_config"] = "foolib"'
-        regular = 'self.cpp_info.name = "Foo"'
-        cmake = 'self.cpp_info.names["cmake"] = "Foo"'
-        cmake_multi = 'self.cpp_info.names["cmake_multi"] = "Foo"'
-        cmake_find = 'self.cpp_info.names["cmake_find_package"] = "Foo"'
-        cmake_find_multi = 'self.cpp_info.names["cmake_find_package_multi"] = "Foo"'
-
-        tools.save('conanfile.py', content=conanfile.replace("{}", regular))
-        output = self.conan(['create', '.', 'name/version@user/test'])
-        self.assertIn("ERROR: [NO TARGET NAME (KB-H040)] "
-                      "CCI uses the name of the package for cmake generator."
-                      " Use 'cpp_info.names' instead.", output)
-
-        for line, gen in [(cmake, "cmake"), (cmake_multi, "cmake_multi")]:
-            tools.save('conanfile.py', content=conanfile.replace("{}", line))
-            output = self.conan(['create', '.', 'name/version@user/test'])
-            self.assertIn("ERROR: [NO TARGET NAME (KB-H040)] CCI uses the name of the package for "
-                          "{0} generator. Conanfile should not contain "
-                          "'self.cpp_info.names['{0}']'. "
-                          " Use 'cmake_find_package' and 'cmake_find_package_multi' instead.".format(gen), output)
-
-        for it in [pkg_config, cmake_find, cmake_find_multi]:
-            tools.save('conanfile.py', content=conanfile.replace("{}", it))
-            output = self.conan(['create', '.', 'name/version@user/test'])
-            self.assertIn("[NO TARGET NAME (KB-H040)] OK", output)
-
     def test_cmake_verbose_makefile(self):
         conanfile = self.conanfile_base.format(placeholder="exports_sources = \"CMakeLists.txt\"")
 

--- a/tests/test_hooks/conan-center/test_no_target_name.py
+++ b/tests/test_hooks/conan-center/test_no_target_name.py
@@ -1,0 +1,66 @@
+import os
+import textwrap
+import pytest
+
+from conans import tools
+
+from tests.utils.test_cases.conan_client import ConanClientTestCase
+
+
+class TestNoTargetName(ConanClientTestCase):
+    conanfile = textwrap.dedent("""\
+                from conans import ConanFile
+                class AConan(ConanFile):
+                    def package_info(self):
+                        {}
+
+                """)
+
+    def _get_environ(self, **kwargs):
+        kwargs = super(TestNoTargetName, self)._get_environ(**kwargs)
+        kwargs.update({'CONAN_HOOKS': os.path.join(os.path.dirname(__file__), '..', '..', '..',
+                                                   'hooks', 'conan-center')})
+        return kwargs
+
+    def test_with_name(self):
+        tools.save('conanfile.py', content=self.conanfile.replace("{}", 'self.cpp_info.name = "Foo"'))
+        output = self.conan(['export', '.', 'name/version@user/test'])
+        self.assertIn("ERROR: [NO TARGET NAME (KB-H040)] CCI uses the name of the package for cmake generator and "
+                      "filename by default. Replace 'cpp_info.name' by 'cpp_info.names[<generator>]'.", output)
+
+    def test_with_filename(self):
+        tools.save('conanfile.py', content=self.conanfile.replace("{}", 'self.cpp_info.filename = "Foobar"'))
+        output = self.conan(['export', '.', 'name/version@user/test'])
+        self.assertIn("ERROR: [NO TARGET NAME (KB-H040)] CCI uses the name of the package for cmake generator and "
+                      "filename by default. Replace 'cpp_info.filename' by 'cpp_info.filenames[<generator>]'.", output)
+
+    def test_with_cmake_generator(self):
+        tools.save('conanfile.py', content=self.conanfile.replace("{}", 'self.cpp_info.names["cmake"] = "Foo"'))
+        output = self.conan(['export', '.', 'name/version@user/test'])
+        self.assertIn("ERROR: [NO TARGET NAME (KB-H040)] CCI uses the name of the package for cmake generator. "
+                      "Conanfile should not contain 'self.cpp_info.names['cmake']'. "
+                      "Use 'cmake_find_package' and 'cmake_find_package_multi' instead.", output)
+
+    def test_with_cmake_multi_generator(self):
+        tools.save('conanfile.py', content=self.conanfile.replace("{}", 'self.cpp_info.names["cmake_multi"] = "Foo"'))
+        output = self.conan(['export', '.', 'name/version@user/test'])
+        self.assertIn("ERROR: [NO TARGET NAME (KB-H040)] CCI uses the name of the package for cmake_multi generator. "
+                      "Conanfile should not contain 'self.cpp_info.names['cmake_multi']'. "
+                      "Use 'cmake_find_package' and 'cmake_find_package_multi' instead.", output)
+
+    def test_with_pkg_config(self):
+        tools.save('conanfile.py', content=self.conanfile.replace("{}", 'self.cpp_info.names["pkg_config"] = "foolib"'))
+        output = self.conan(['export', '.', 'name/version@user/test'])
+        self.assertIn("[NO TARGET NAME (KB-H040)] OK", output)
+
+    def test_with_cmake_find_package(self):
+        tools.save('conanfile.py', content=self.conanfile.replace("{}", 'self.cpp_info.names["cmake_find_package"] = '
+                                                                        '"foolib"'))
+        output = self.conan(['export', '.', 'name/version@user/test'])
+        self.assertIn("[NO TARGET NAME (KB-H040)] OK", output)
+
+    def test_with_cmake_find_package_multi(self):
+        tools.save('conanfile.py', content=self.conanfile.replace("{}", 'self.cpp_info.names'
+                                                                        '["cmake_find_package_multi"] = "foolib"'))
+        output = self.conan(['export', '.', 'name/version@user/test'])
+        self.assertIn("[NO TARGET NAME (KB-H040)] OK", output)


### PR DESCRIPTION
Both `cpp_info.name` and `cpp_info.filename` are deprecated and should by replaced.

Related to #374