### PR TITLE
[conan-center] KB-H070 Settings is mandatory

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -74,6 +74,7 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H065": "NO REQUIRED_CONAN_VERSION",
              "KB-H066": "SHORT_PATHS USAGE",
              "KB-H068": "TEST_TYPE MANAGEMENT",
+             "KB-H070": "MANDATORY SETTINGS",
              }
 
 
@@ -793,6 +794,13 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
                     out.error(f"The attribute 'test_type' only should be used with 'explicit' value.: {test_type}")
             except Exception as e:
                 out.warn("Invalid conanfile: {}".format(e))
+
+
+    @run_test("KB-H070", output)
+    def test(out):
+        settings = getattr(conanfile, "settings", None)
+        if not settings:
+            out.warn("No 'settings' detected in your conanfile.py. Add 'settings' attribute and use 'package_id(self)' to manage.")
 
 
 @raise_if_error_output

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -800,7 +800,7 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
     def test(out):
         settings = getattr(conanfile, "settings", None)
         if not settings:
-            out.warn("No 'settings' detected in your conanfile.py. Add 'settings' attribute and use 'package_id(self)' to manage.")
+            out.warn("No 'settings' detected in your conanfile.py. Add 'settings' attribute and use 'package_id(self)' method to manage the package ID.")
 
 
 @raise_if_error_output

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -799,7 +799,13 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
     @run_test("KB-H070", output)
     def test(out):
         settings = getattr(conanfile, "settings", None)
-        if not settings:
+        if settings:
+            settings = settings if isinstance(settings, (list, tuple)) else [settings]
+            missing = [x for x in ["os", "arch", "compiler", "build_type"] if x not in settings]
+            if missing:
+                out.warn("The values '{}' are missing on 'settings' attribute. Update settings with the missing "
+                         "values and use 'package_id(self)' method to manage the package ID.".format("', '".join(missing)))
+        else:
             out.warn("No 'settings' detected in your conanfile.py. Add 'settings' attribute and use 'package_id(self)' method to manage the package ID.")
 
 

--- a/tests/test_hooks/conan-center/test_settings_attr.py
+++ b/tests/test_hooks/conan-center/test_settings_attr.py
@@ -34,4 +34,4 @@ class SettingsAttrTests(ConanClientTestCase):
         output = self.conan(['export', '.', 'name/version@user/channel'])
         self.assertIn("WARN: [MANDATORY SETTINGS (KB-H070)] "
                       "No 'settings' detected in your conanfile.py. "
-                      "Add 'settings' attribute and use 'package_id(self)' to manage.", output)
+                      "Add 'settings' attribute and use 'package_id(self)' method to manage the package ID.", output)

--- a/tests/test_hooks/conan-center/test_settings_attr.py
+++ b/tests/test_hooks/conan-center/test_settings_attr.py
@@ -1,0 +1,37 @@
+import os
+import textwrap
+
+from conans import tools
+
+from tests.utils.test_cases.conan_client import ConanClientTestCase
+
+
+class SettingsAttrTests(ConanClientTestCase):
+    conanfile = textwrap.dedent("""\
+        import os
+        from conans import ConanFile, tools
+
+        class AConan(ConanFile):
+           {}
+           pass
+ 
+        """)
+
+    def _get_environ(self, **kwargs):
+        kwargs = super(SettingsAttrTests, self)._get_environ(**kwargs)
+        kwargs.update({'CONAN_HOOKS': os.path.join(os.path.dirname(__file__), '..', '..', '..',
+                                                   'hooks', 'conan-center')})
+        return kwargs
+
+    def test_with_settings(self):
+        tools.save('conanfile.py', content=self.conanfile.replace("{}", "settings = 'os'"))
+        output = self.conan(['export', '.', 'name/version@user/channel'])
+        self.assertNotIn("WARN: [MANDATORY SETTINGS (KB-H070)]", output)
+        self.assertIn("[MANDATORY SETTINGS (KB-H070)] OK", output)
+
+    def test_without_settings(self):
+        tools.save('conanfile.py', content=self.conanfile)
+        output = self.conan(['export', '.', 'name/version@user/channel'])
+        self.assertIn("WARN: [MANDATORY SETTINGS (KB-H070)] "
+                      "No 'settings' detected in your conanfile.py. "
+                      "Add 'settings' attribute and use 'package_id(self)' to manage.", output)

--- a/tests/test_hooks/conan-center/test_settings_attr.py
+++ b/tests/test_hooks/conan-center/test_settings_attr.py
@@ -24,7 +24,7 @@ class SettingsAttrTests(ConanClientTestCase):
         return kwargs
 
     def test_with_settings(self):
-        tools.save('conanfile.py', content=self.conanfile.replace("{}", "settings = 'os'"))
+        tools.save('conanfile.py', content=self.conanfile.replace("{}", "settings = 'os', 'arch', 'compiler', 'build_type'"))
         output = self.conan(['export', '.', 'name/version@user/channel'])
         self.assertNotIn("WARN: [MANDATORY SETTINGS (KB-H070)]", output)
         self.assertIn("[MANDATORY SETTINGS (KB-H070)] OK", output)
@@ -35,3 +35,19 @@ class SettingsAttrTests(ConanClientTestCase):
         self.assertIn("WARN: [MANDATORY SETTINGS (KB-H070)] "
                       "No 'settings' detected in your conanfile.py. "
                       "Add 'settings' attribute and use 'package_id(self)' method to manage the package ID.", output)
+
+    def test_missing_settings_values(self):
+        tools.save('conanfile.py', content=self.conanfile.replace("{}", "settings = 'os'"))
+        output = self.conan(['export', '.', 'name/version@user/channel'])
+        self.assertIn("WARN: [MANDATORY SETTINGS (KB-H070)] The values 'arch', 'compiler', 'build_type' are missing on "
+                      "'settings' attribute. Update settings with the missing values and use 'package_id(self)' method "
+                      "to manage the package ID.", output)
+        self.assertIn("[MANDATORY SETTINGS (KB-H070)] OK", output)
+
+    def test_missing_settings_single_value(self):
+        tools.save('conanfile.py', content=self.conanfile.replace("{}", "settings = 'os', 'arch', 'build_type'"))
+        output = self.conan(['export', '.', 'name/version@user/channel'])
+        self.assertIn("WARN: [MANDATORY SETTINGS (KB-H070)] The values 'compiler' are missing on "
+                      "'settings' attribute. Update settings with the missing values and use 'package_id(self)' method "
+                      "to manage the package ID.", output)
+        self.assertIn("[MANDATORY SETTINGS (KB-H070)] OK", output)


### PR DESCRIPTION
I would love to convert it to an error message, but doing a check, we have 89 recipes without settings on conan center index.

```python
import os
from conans.client.graph.python_requires import ConanPythonRequire
from conans.client.loader import parse_conanfile

if __name__ == "__main__":
    walk_dir = <recipes folder path>
    counter = 0
    for root, subdirs, files in os.walk(walk_dir):
        for filename in files:
            if "conanfile.py" in filename:
                try:
                    python_requires = ConanPythonRequire(None, None)
                    conanfile_path = os.path.join(root, filename)
                    _, conanfile = parse_conanfile(conanfile_path, python_requires=python_requires, generator_manager=None)
                    settings = getattr(conanfile, "settings", None)
                    if not settings:
                        print(conanfile_path)
    print(f"count: {counter}")
```

closes #371