### PR TITLE
Checksum entries must be filled

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -427,14 +427,11 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
                         return
             for element in conandata_yml[entry][version]:
                 if entry == "sources" and element in allowed_sources and not conandata_yml[entry][version][element]:
-                    out.error(f"The entry {element} cannot be empty in conandata.yml.")
-                if entry == "sources" and element in weak_checksums:
-                    out.warn(f"Consider 'sha256' instead of {weak_checksums}. It's considerably more secure than others.")
+                    out.error(f"The entry '{element}' cannot be empty in conandata.yml.")
                 if entry == "sources" and element in checksums:
                     found_checksums.append(element)
-            if found_checksums:
-                if len(found_checksums) > 1 and 'sha256' in found_checksums:
-                    out.warn("Use only 'sha256' as checksum. It's considerably more secure than others.")
+            if found_checksums and 'sha256' not in found_checksums:
+                out.warn(f"Consider 'sha256' instead of {weak_checksums}. It's considerably more secure than others.")
 
 
     @run_test("KB-H034", output)

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -363,7 +363,7 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
         conandata_path = os.path.join(export_folder_path, "conandata.yml")
         version = conanfile.version
         allowed_first_level = ["sources", "patches"]
-        allowed_sources = ["url", "sha256", "sha1", "md5"]
+        allowed_sources = ["md5", "sha1", "sha256", "url"]
         allowed_patches = ["patch_file", "base_path", "url", "sha256", "sha1", "md5"]
 
         def _not_allowed_entries(info, allowed_entries):
@@ -422,6 +422,10 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
                     if not validate_recursive(element, conandata_yml[entry][version], "sources",
                                               allowed_sources):
                         return
+            for element in conandata_yml[entry][version]:
+                if entry == "sources" and element in allowed_sources and not conandata_yml[entry][version][element]:
+                    out.error(f"The entries {allowed_sources} must be filled in conandata.yml.")
+
 
     @run_test("KB-H034", output)
     def test(out):
@@ -1488,4 +1492,3 @@ def _load_conanfile(conanfile_path):
                                        python_requires=python_requires,
                                        generator_manager=None)
     return conanfile_obj
-

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -365,6 +365,7 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
         allowed_first_level = ["sources", "patches"]
         allowed_sources = ["md5", "sha1", "sha256", "url"]
         allowed_patches = ["patch_file", "base_path", "url", "sha256", "sha1", "md5"]
+        weak_checksums = ["md5", "sha1"]
 
         def _not_allowed_entries(info, allowed_entries):
             not_allowed = []
@@ -425,6 +426,8 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
             for element in conandata_yml[entry][version]:
                 if entry == "sources" and element in allowed_sources and not conandata_yml[entry][version][element]:
                     out.error(f"The entries {allowed_sources} must be filled in conandata.yml.")
+                if entry == "sources" and element in weak_checksums:
+                    out.warn(f"Consider 'sha256' instead of {weak_checksums}. It's considerably more secure than others.")
 
 
     @run_test("KB-H034", output)

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -366,6 +366,8 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
         allowed_sources = ["md5", "sha1", "sha256", "url"]
         allowed_patches = ["patch_file", "base_path", "url", "sha256", "sha1", "md5"]
         weak_checksums = ["md5", "sha1"]
+        checksums = ["md5", "sha1", "sha256"]
+        found_checksums = []
 
         def _not_allowed_entries(info, allowed_entries):
             not_allowed = []
@@ -428,6 +430,11 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
                     out.error(f"The entries {allowed_sources} must be filled in conandata.yml.")
                 if entry == "sources" and element in weak_checksums:
                     out.warn(f"Consider 'sha256' instead of {weak_checksums}. It's considerably more secure than others.")
+                if entry == "sources" and element in checksums:
+                    found_checksums.append(element)
+            if found_checksums:
+                if len(found_checksums) > 1 and 'sha256' in found_checksums:
+                    out.warn("Use only 'sha256' as checksum. It's considerably more secure than others.")
 
 
     @run_test("KB-H034", output)

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -427,7 +427,7 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
                         return
             for element in conandata_yml[entry][version]:
                 if entry == "sources" and element in allowed_sources and not conandata_yml[entry][version][element]:
-                    out.error(f"The entries {allowed_sources} must be filled in conandata.yml.")
+                    out.error(f"The entry {element} cannot be empty in conandata.yml.")
                 if entry == "sources" and element in weak_checksums:
                     out.warn(f"Consider 'sha256' instead of {weak_checksums}. It's considerably more secure than others.")
                 if entry == "sources" and element in checksums:

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -368,6 +368,7 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
         weak_checksums = ["md5", "sha1"]
         checksums = ["md5", "sha1", "sha256"]
         found_checksums = []
+        has_sources = False
 
         def _not_allowed_entries(info, allowed_entries):
             not_allowed = []
@@ -414,6 +415,25 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
                 else:
                     return validate_one(e, name, allowed)
 
+            def validate_checksum_recursive(e, data):
+                if isinstance(e, str) and e not in allowed_sources and not isinstance(data[e], str):
+                    for child in data[e]:
+                        if not validate_checksum_recursive(child, data[e]):
+                            return False
+                    return True
+                else:
+                    if isinstance(e, dict):
+                        for k, v in e.items():
+                            if k in checksums:
+                                found_checksums.append(k)
+                                if not v:
+                                    out.error(f"The entry '{k}' cannot be empty in conandata.yml.")
+                    else:
+                        fields = e if isinstance(e, list) else [e]
+                        for field in fields:
+                            if field in checksums:
+                                found_checksums.append(field)
+
             if version not in conandata_yml[entry]:
                 continue
             for element in conandata_yml[entry][version]:
@@ -426,11 +446,12 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
                                               allowed_sources):
                         return
             for element in conandata_yml[entry][version]:
-                if entry == "sources" and element in allowed_sources and not conandata_yml[entry][version][element]:
-                    out.error(f"The entry '{element}' cannot be empty in conandata.yml.")
-                if entry == "sources" and element in checksums:
-                    found_checksums.append(element)
-            if found_checksums and 'sha256' not in found_checksums:
+                if entry == "sources":
+                    has_sources = True
+                    validate_checksum_recursive(element, conandata_yml[entry][version])
+            if not found_checksums and has_sources:
+                out.error("The checksum key 'sha256' must be declared and can not be empty.")
+            elif found_checksums and 'sha256' not in found_checksums:
                 out.warn(f"Consider 'sha256' instead of {weak_checksums}. It's considerably more secure than others.")
 
 

--- a/tests/test_hooks/conan-center/test_conandata.py
+++ b/tests/test_hooks/conan-center/test_conandata.py
@@ -431,5 +431,18 @@ class ConanData(ConanClientTestCase):
         tools.save('conandata.yml', content=conandata)
         output = self.conan(['export', '.', 'name/1.70.0@jgsogo/test'])
         self.assertIn("ERROR: [CONANDATA.YML FORMAT (KB-H030)]", output)
-        self.assertNotIn("First level entries", output)
         self.assertIn("The entries ['md5', 'sha1', 'sha256', 'url'] must be filled in conandata.yml.", output)
+
+    def test_prefer_sha256(self):
+        tools.save('conanfile.py', content=self.conanfile)
+        for checksum in ['md5', 'sha1']:
+            conandata = textwrap.dedent(f"""
+                sources:
+                  "1.70.0":
+                    url: "url1.69.0"
+                    {checksum}: "cf23df2207d99a74fbe169e3eba035e633b65d94"
+                """)
+            tools.save('conandata.yml', content=conandata)
+            output = self.conan(['export', '.', 'name/1.70.0@jgsogo/test'])
+            self.assertIn("WARN: [CONANDATA.YML FORMAT (KB-H030)]", output)
+            self.assertIn("Consider 'sha256' instead of ['md5', 'sha1']. It's considerably more secure than others.", output)

--- a/tests/test_hooks/conan-center/test_conandata.py
+++ b/tests/test_hooks/conan-center/test_conandata.py
@@ -419,3 +419,17 @@ class ConanData(ConanClientTestCase):
         self.assertNotIn("First level entries", output)
         self.assertIn("Additional entries ['other_field'] not allowed in 'patches':'1.70.0' "
                       "of conandata.yml", output)
+
+    def test_empty_checksum(self):
+        tools.save('conanfile.py', content=self.conanfile)
+        conandata = textwrap.dedent("""
+            sources:
+              "1.70.0":
+                url: "url1.69.0"
+                sha256: ""
+            """)
+        tools.save('conandata.yml', content=conandata)
+        output = self.conan(['export', '.', 'name/1.70.0@jgsogo/test'])
+        self.assertIn("ERROR: [CONANDATA.YML FORMAT (KB-H030)]", output)
+        self.assertNotIn("First level entries", output)
+        self.assertIn("The entries ['md5', 'sha1', 'sha256', 'url'] must be filled in conandata.yml.", output)

--- a/tests/test_hooks/conan-center/test_conandata.py
+++ b/tests/test_hooks/conan-center/test_conandata.py
@@ -447,3 +447,47 @@ class ConanData(ConanClientTestCase):
             output = self.conan(['export', '.', 'name/1.70.0@jgsogo/test'])
             self.assertIn("WARN: [CONANDATA.YML FORMAT (KB-H030)]", output)
             self.assertIn("Consider 'sha256' instead of ['md5', 'sha1']. It's considerably more secure than others.", output)
+
+            conandata = textwrap.dedent(f"""
+                            sources:
+                              "1.69.0":
+                                url: "url1.69.0"
+                                {checksum}: "cf23df2207d99a74fbe169e3eba035e633b65d94"
+                              "1.70.0":
+                                url: "url1.70.0"
+                                {checksum}: "cf23df2207d99a74fbe169e3eba035e633b65d94"
+                            """)
+            tools.save('conandata.yml', content=conandata)
+            output = self.conan(['export', '.', 'name/1.70.0@jgsogo/test'])
+            self.assertIn("WARN: [CONANDATA.YML FORMAT (KB-H030)]", output)
+            self.assertIn("Consider 'sha256' instead of ['md5', 'sha1']. It's considerably more secure than others.",
+                          output)
+
+    def test_empty_checksum(self):
+        tools.save('conanfile.py', content=self.conanfile)
+        conandata = textwrap.dedent(f"""
+            sources:
+                "1.70.0":
+                    url: "url1.69.0"
+            """)
+        tools.save('conandata.yml', content=conandata)
+        output = self.conan(['export', '.', 'name/1.70.0@jgsogo/test'])
+        self.assertIn("ERROR: [CONANDATA.YML FORMAT (KB-H030)]", output)
+        self.assertIn("The checksum key 'sha256' must be declared and can not be empty.", output)
+
+        conandata = textwrap.dedent("""
+                    sources:
+                      "1.69.0":
+                        url: "url1.69.0"
+                        sha256: "sha1.69.0"
+                      "1.70.0":
+                        url: "url1.70.0"
+                    patches:
+                      "1.70.0":
+                        - patch_file: "001-1.70.0.patch"
+                          base_path: "source_subfolder/1.70.0"
+                    """)
+        tools.save('conandata.yml', content=conandata)
+        output = self.conan(['export', '.', 'name/1.70.0@jgsogo/test'])
+        self.assertIn("ERROR: [CONANDATA.YML FORMAT (KB-H030)]", output)
+        self.assertIn("The checksum key 'sha256' must be declared and can not be empty.", output)

--- a/tests/test_hooks/conan-center/test_conandata.py
+++ b/tests/test_hooks/conan-center/test_conandata.py
@@ -262,6 +262,8 @@ class ConanData(ConanClientTestCase):
         tools.save('conandata.yml', content=conandata)
         export_output = self.conan(['export', '.', 'name/1.69.0@jgsogo/test'])
         self.assertNotIn("ERROR: [CONANDATA.YML FORMAT (KB-H030)]", export_output)
+        self.assertIn("WARN: [CONANDATA.YML FORMAT (KB-H030)]", export_output)
+        self.assertIn("Use only 'sha256' as checksum. It's considerably more secure than others.", export_output)
         self.assertIn("[CONANDATA.YML FORMAT (KB-H030)] OK", export_output)
 
     def test_reduce_conandata(self):

--- a/tests/test_hooks/conan-center/test_conandata.py
+++ b/tests/test_hooks/conan-center/test_conandata.py
@@ -262,8 +262,7 @@ class ConanData(ConanClientTestCase):
         tools.save('conandata.yml', content=conandata)
         export_output = self.conan(['export', '.', 'name/1.69.0@jgsogo/test'])
         self.assertNotIn("ERROR: [CONANDATA.YML FORMAT (KB-H030)]", export_output)
-        self.assertIn("WARN: [CONANDATA.YML FORMAT (KB-H030)]", export_output)
-        self.assertIn("Use only 'sha256' as checksum. It's considerably more secure than others.", export_output)
+        self.assertNotIn("WARN: [CONANDATA.YML FORMAT (KB-H030)]", export_output)
         self.assertIn("[CONANDATA.YML FORMAT (KB-H030)] OK", export_output)
 
     def test_reduce_conandata(self):
@@ -433,7 +432,7 @@ class ConanData(ConanClientTestCase):
         tools.save('conandata.yml', content=conandata)
         output = self.conan(['export', '.', 'name/1.70.0@jgsogo/test'])
         self.assertIn("ERROR: [CONANDATA.YML FORMAT (KB-H030)]", output)
-        self.assertIn("The entries ['md5', 'sha1', 'sha256', 'url'] must be filled in conandata.yml.", output)
+        self.assertIn("The entry 'sha256' cannot be empty in conandata.yml.", output)
 
     def test_prefer_sha256(self):
         tools.save('conanfile.py', content=self.conanfile)


### PR DESCRIPTION
The entries `['md5', 'sha1', 'sha256', 'url']`can not be used as an empty key. Otherwise, it will be considered an error.

fixes #406