### PR TITLE
[conan-center] KB-H030 need to accept a new edge case

### DIFF
--- a/.ci/generate_env_macos.sh
+++ b/.ci/generate_env_macos.sh
@@ -23,11 +23,10 @@ esac
 TEST_FOLDER=${TMPDIR}/${PYVER}
 mkdir -p ${TEST_FOLDER} || echo "ok"
 ${PYVER} -m pip install tox==3.7.0 tox-venv==0.3.1 requests virtualenv
-${PYVER} -m pip install -U platformdirs
 ${PYVER} -m virtualenv --python ${PYVER} ${TEST_FOLDER} && \
   source ${TEST_FOLDER}/bin/activate && \
   python --version && \
-  python -m pip install --upgrade pip && \
+  python -m pip install --upgrade pip platformdirs && \
   python -m pip install --requirement .ci/requirements_macos.txt && \
   python .ci/last_conan_version.py
 

--- a/.ci/generate_env_macos.sh
+++ b/.ci/generate_env_macos.sh
@@ -26,7 +26,7 @@ ${PYVER} -m pip install tox==3.7.0 tox-venv==0.3.1 requests virtualenv
 ${PYVER} -m virtualenv --python ${PYVER} ${TEST_FOLDER} && \
   source ${TEST_FOLDER}/bin/activate && \
   python --version && \
-  python -m pip install --upgrade --user pip && \
-  python -m pip install --user --requirement .ci/requirements_macos.txt && \
+  python -m pip install --upgrade pip && \
+  python -m pip install --upgrade --requirement .ci/requirements_macos.txt && \
   python .ci/last_conan_version.py
 

--- a/.ci/generate_env_macos.sh
+++ b/.ci/generate_env_macos.sh
@@ -4,6 +4,7 @@ set -e
 set -x
 
 # https://github.com/conan-io/conan_ci_jenkins/blob/master/resources/org/jfrog/conanci/python_runner/conf.py
+TEST_FOLDER="${TMPDIR}/${PYVER}"
 
 case "${PYVER}" in
     py36)
@@ -20,7 +21,6 @@ case "${PYVER}" in
         ;;
 esac
 
-TEST_FOLDER=${TMPDIR}/${PYVER}
 mkdir -p ${TEST_FOLDER} || echo "ok"
 ${PYVER} -m pip install tox==3.7.0 tox-venv==0.3.1 requests
 ${PYVER} -m venv ${TEST_FOLDER} && \

--- a/.ci/generate_env_macos.sh
+++ b/.ci/generate_env_macos.sh
@@ -26,7 +26,7 @@ ${PYVER} -m pip install tox==3.7.0 tox-venv==0.3.1 requests virtualenv
 ${PYVER} -m virtualenv --python ${PYVER} ${TEST_FOLDER} && \
   source ${TEST_FOLDER}/bin/activate && \
   python --version && \
-  python -m pip install --upgrade pip platformdirs && \
-  python -m pip install --requirement .ci/requirements_macos.txt && \
+  python -m pip install --upgrade --user pip && \
+  python -m pip install --user --requirement .ci/requirements_macos.txt && \
   python .ci/last_conan_version.py
 

--- a/.ci/generate_env_macos.sh
+++ b/.ci/generate_env_macos.sh
@@ -22,8 +22,8 @@ esac
 
 TEST_FOLDER=${TMPDIR}/${PYVER}
 mkdir -p ${TEST_FOLDER} || echo "ok"
-${PYVER} -m pip install tox==3.7.0 tox-venv==0.3.1 requests virtualenv
-${PYVER} -m virtualenv --python ${PYVER} ${TEST_FOLDER} && \
+${PYVER} -m pip install tox==3.7.0 tox-venv==0.3.1 requests
+${PYVER} -m venv ${TEST_FOLDER} && \
   source ${TEST_FOLDER}/bin/activate && \
   python --version && \
   python -m pip install --upgrade pip && \

--- a/.ci/generate_env_macos.sh
+++ b/.ci/generate_env_macos.sh
@@ -22,7 +22,7 @@ esac
 
 TEST_FOLDER=${TMPDIR}/${PYVER}
 mkdir -p ${TEST_FOLDER} || echo "ok"
-${PYVER} -m pip install tox==3.7.0 tox-venv==0.3.1 requests virtualenv
+${PYVER} -m pip install tox tox-venv requests virtualenv
 ${PYVER} -m virtualenv --python ${PYVER} ${TEST_FOLDER} && \
   source ${TEST_FOLDER}/bin/activate && \
   python --version && \

--- a/.ci/generate_env_macos.sh
+++ b/.ci/generate_env_macos.sh
@@ -22,7 +22,8 @@ esac
 
 TEST_FOLDER=${TMPDIR}/${PYVER}
 mkdir -p ${TEST_FOLDER} || echo "ok"
-${PYVER} -m pip install tox tox-venv requests virtualenv
+${PYVER} -m pip install tox==3.7.0 tox-venv==0.3.1 requests virtualenv
+${PYVER} -m pip install -U platformdirs
 ${PYVER} -m virtualenv --python ${PYVER} ${TEST_FOLDER} && \
   source ${TEST_FOLDER}/bin/activate && \
   python --version && \

--- a/.ci/generate_env_windows.bat
+++ b/.ci/generate_env_windows.bat
@@ -2,6 +2,8 @@ set PATH=%PATH%;C:/Python36/Scripts/
 pip install --timeout 100 --retries 10 tox==3.7.0 tox-venv==0.3.1 requests virtualenv
 python .ci/last_conan_version.py
 
+set TEST_FOLDER=D:/J/t/Hooks/%BUILD_NUMBER%/%PYVER%
+
 IF "%PYVER%"=="py39" (
     set PYVER="Python39"
 )
@@ -11,7 +13,7 @@ IF "%PYVER%"=="py38" (
 IF "%PYVER%"=="py36" (
     set PYVER="Python36"
 )
-set TEST_FOLDER=D:/J/t/Hooks/%BUILD_NUMBER%/%PYVER%
+
 
 virtualenv --python "C:/%PYVER%/python.exe" %TEST_FOLDER% && %TEST_FOLDER%/Scripts/activate && python --version
 python -m pip install pip --upgrade

--- a/.ci/run_tox.sh
+++ b/.ci/run_tox.sh
@@ -4,6 +4,7 @@ set -e
 set -x
 
 # https://github.com/conan-io/conan_ci_jenkins/blob/master/resources/org/jfrog/conanci/python_runner/conf.py
+TEST_FOLDER=${TMPDIR}/${PYVER}
 
 case "${PYVER}" in
     py36)
@@ -20,7 +21,6 @@ case "${PYVER}" in
         ;;
 esac
 
-TEST_FOLDER=${TMPDIR}/${PYVER}
 source ${TEST_FOLDER}/bin/activate
 
 ${PYVER} -m tox --recreate

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -418,9 +418,7 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
             def validate_checksum_recursive(e, data):
                 if isinstance(e, str) and e not in allowed_sources and not isinstance(data[e], str):
                     for child in data[e]:
-                        if not validate_checksum_recursive(child, data[e]):
-                            return False
-                    return True
+                        validate_checksum_recursive(child, data[e])
                 else:
                     if isinstance(e, dict):
                         for k, v in e.items():

--- a/tests/test_hooks/conan-center/test_conandata.py
+++ b/tests/test_hooks/conan-center/test_conandata.py
@@ -491,3 +491,46 @@ class ConanData(ConanClientTestCase):
         output = self.conan(['export', '.', 'name/1.70.0@jgsogo/test'])
         self.assertIn("ERROR: [CONANDATA.YML FORMAT (KB-H030)]", output)
         self.assertIn("The checksum key 'sha256' must be declared and can not be empty.", output)
+
+    def test_zulu_openjdk(self):
+        tools.save('conanfile.py', content=self.conanfile)
+        conandata = textwrap.dedent("""
+            sources:
+              "11.0.8":
+                "Windows": {
+                  "url": "https://cdn.azul.com/zulu/bin/zulu11.41.23-ca-jdk11.0.8-win_x64.zip",
+                  "sha256": "3602ed7bae52898c540c2d3ae3230c081cf061b219d14fb9ac15a47f4226d307",
+                }
+                "Linux": {
+                  "url": "https://cdn.azul.com/zulu/bin/zulu11.41.23-ca-jdk11.0.8-linux_x64.tar.gz",
+                  "sha256": "f8aee4ab30ca11ab3c8f401477df0e455a9d6b06f2710b2d1b1ddcf06067bc79",
+                }
+                "Macos": {
+                  "url": "https://cdn.azul.com/zulu/bin/zulu11.41.23-ca-jdk11.0.8-macosx_x64.tar.gz",
+                  "sha256": "1ed070ea9a27030bcca4d7c074dec1d205d3f3506166d36faf4d1b9e083ab365",
+                }
+            
+              "11.0.12":
+                "Windows":
+                  "x86_64": {
+                    "url": "https://cdn.azul.com/zulu/bin/zulu11.50.19-ca-jdk11.0.12-win_x64.zip",
+                    "sha256": "42ae65e75d615a3f06a674978e1fa85fdf078cad94e553fee3e779b2b42bb015",
+                  }
+                "Linux":
+                  "x86_64": {
+                    "url": "https://cdn.azul.com/zulu/bin/zulu11.50.19-ca-jdk11.0.12-linux_x64.tar.gz",
+                    "sha256": "b8e8a63b79bc312aa90f3558edbea59e71495ef1a9c340e38900dd28a1c579f3",
+                  }
+                "Macos":
+                  "x86_64": {
+                    "url": "https://cdn.azul.com/zulu/bin/zulu11.50.19-ca-jdk11.0.12-macosx_x64.tar.gz",
+                    "sha256": "0b8c8b7cf89c7c55b7e2239b47201d704e8d2170884875b00f3103cf0662d6d7",
+                  }
+                  "armv8" : {
+                    "url": "https://cdn.azul.com/zulu/bin/zulu11.50.19-ca-jdk11.0.12-macosx_aarch64.tar.gz",
+                    "sha256": "e908a0b4c0da08d41c3e19230f819b364ff2e5f1dafd62d2cf991a85a34d3a17",
+                  }
+        """)
+        tools.save('conandata.yml', content=conandata)
+        output = self.conan(['export', '.', 'zulu-openjdk/11.0.12@user/testing'])
+        self.assertIn("[CONANDATA.YML FORMAT (KB-H030)] OK", output)


### PR DESCRIPTION
The official recipe zulu-openjdk uses pre-built binaries which is not covered by the current implementation of conan-center hook.

Related to https://github.com/conan-io/conan-center-index/pull/10592#issuecomment-1115887260

**NOTE**: For some reason mac was failing due max path length. I needed to change the test folder path to `/tmp/py39` (example) and it works now.
