### PR TITLE
[conan-center] Do not allow build_policy attribute

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -473,9 +473,11 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
 
     @run_test("KB-H039", output)
     def test(out):
+        search_attrs = ["scm", "build_policy"]
         forbidden_attrs = []
-        if getattr(conanfile, "scm", None):
-            forbidden_attrs.append("scm")
+        for attr in search_attrs:
+            if getattr(conanfile, attr, None):
+                forbidden_attrs.append(attr)
         if re.search(r"revision_mode\s=", conanfile_content):
             forbidden_attrs.append("revision_mode")
 

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -719,6 +719,16 @@ class ConanCenterTests(ConanClientTestCase):
         output = self.conan(['export', '.', 'name/version@user/test'], expected_return_code=ERROR_GENERAL)
         self.assertIn("ERROR: [NOT ALLOWED ATTRIBUTES (KB-H039)] Conanfile should not contain attributes: 'scm'", output)
 
+    def test_no_build_policy(self):
+        conanfile = textwrap.dedent("""\
+        from conans import ConanFile
+        class AConan(ConanFile):
+            build_policy = "always"
+        """)
+        tools.save('conanfile.py', content=conanfile)
+        output = self.conan(['export', '.', 'name/version@user/test'])
+        self.assertIn("ERROR: [NOT ALLOWED ATTRIBUTES (KB-H039)] Conanfile should not contain attributes: 'build_policy'", output)
+
     def test_cmake_verbose_makefile(self):
         conanfile = self.conanfile_base.format(placeholder="exports_sources = \"CMakeLists.txt\"")
 


### PR DESCRIPTION
The build policy on Conan Center should be only managed by the CI service. Users should not force any custom build policy.

So far, we don't have any recipe in CCI with build_policy.