### PR TITLE
[conan-center] create-dmg should be accepted as header-only

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1057,6 +1057,7 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
             "xorg-cf-files",
             "xorg-macros",
             "opentelemetry-proto",
+            "create-dmg"
         ]:
             return
         if not _files_match_settings(conanfile, conanfile.package_folder, out):


### PR DESCRIPTION
That project only exports a single file which is a script. It does matters any setting.

/cc @MartinDelille

Related to https://github.com/conan-io/conan-center-index/pull/10382