### PR TITLE
Use Python 3.7 for Mac

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -37,50 +37,50 @@ pipeline {
                         }
                     }
                 }
-                stage('Macos - py39') {
+                stage('Macos - py37') {
                     agent {
                         label 'Macos'
                     }
                     stages {
-                        stage('Macos - py39 - Generate environment') {
+                        stage('Macos - py37 - Generate environment') {
                             environment {
-                                PYVER = 'py39'
+                                PYVER = 'py37'
                             }
                             steps {
                                 sh '.ci/generate_env_macos.sh'
                             }
                         }
-                        stage('Macos - py39 - conandev') {
+                        stage('Macos - py37 - conandev') {
                             environment {
-                                PYVER = 'py39'
-                                TOXENV = 'py39-conandev'
+                                PYVER = 'py37'
+                                TOXENV = 'py37-conandev'
                             }
                             steps {
                                 sh '.ci/run_tox.sh'
                             }
                         }
-                        stage('Macos - py39 - conancurrent') {
+                        stage('Macos - py37 - conancurrent') {
                             environment {
-                                PYVER = 'py39'
-                                TOXENV = 'py39-conancurrent'
+                                PYVER = 'py37'
+                                TOXENV = 'py37-conancurrent'
                             }
                             steps {
                                 sh '.ci/run_tox.sh'
                             }
                         }
-                        stage('Macos - py39 - conanprev') {
+                        stage('Macos - py37 - conanprev') {
                             environment {
-                                PYVER = 'py39'
-                                TOXENV = 'py39-conanprev'
+                                PYVER = 'py37'
+                                TOXENV = 'py37-conanprev'
                             }
                             steps {
                                 sh '.ci/run_tox.sh'
                             }
                         }
-                        stage('Macos - py39 - conanprevprev') {
+                        stage('Macos - py37 - conanprevprev') {
                             environment {
-                                PYVER = 'py39'
-                                TOXENV = 'py39-conanprevprev'
+                                PYVER = 'py37'
+                                TOXENV = 'py37-conanprevprev'
                             }
                             steps {
                                 sh '.ci/run_tox.sh'
@@ -124,30 +124,30 @@ pipeline {
                         }
                     }
                 }
-                stage('Windows - py39') {
+                stage('Windows - py37') {
                     agent {
                         label 'Windows'
                     }
                     stages {
-                        stage('Windows - py39 - Generate environment') {
+                        stage('Windows - py37 - Generate environment') {
                             environment {
-                                PYVER = 'py39'
+                                PYVER = 'py37'
                             }
                             steps {
                                 bat '.ci/generate_env_windows.bat'
                             }
                         }
-                        stage('Windows - py39 - conancurrent') {
+                        stage('Windows - py37 - conancurrent') {
                             environment {
-                                TOXENV = 'py39-conancurrent'
+                                TOXENV = 'py37-conancurrent'
                             }
                             steps {
                                 bat 'tox --recreate'
                             }
                         }
-                        stage('Windows - py39 - conanprev') {
+                        stage('Windows - py37 - conanprev') {
                             environment {
-                                TOXENV = 'py39-conanprev'
+                                TOXENV = 'py37-conanprev'
                             }
                             steps {
                                 bat 'tox --recreate'
@@ -199,22 +199,22 @@ pipeline {
                         }
                     }
                 }
-                stage('Linux - py39') {
+                stage('Linux - py37') {
                     agent {
                         label 'Linux'
                     }
                     stages {
-                        stage('Linux - py39 - Generate environment') {
+                        stage('Linux - py37 - Generate environment') {
                             environment {
-                                PYVER = 'py39'
+                                PYVER = 'py37'
                             }
                             steps {
                                 sh '.ci/generate_env_linux.sh'
                             }
                         }
-                        stage('Linux - py39 - conandev') {
+                        stage('Linux - py37 - conandev') {
                             environment {
-                                TOXENV = 'py39-conandev'
+                                TOXENV = 'py37-conandev'
                             }
                             steps {
                                 sh '''
@@ -224,9 +224,9 @@ pipeline {
                                 '''
                             }
                         }
-                        stage('Linux - py39 - conancurrent') {
+                        stage('Linux - py37 - conancurrent') {
                             environment {
-                                TOXENV = 'py39-conancurrent'
+                                TOXENV = 'py37-conancurrent'
                             }
                             steps {
                                 sh '''
@@ -236,9 +236,9 @@ pipeline {
                                 '''
                             }
                         }
-                        stage('Linux - py39 - conanprev') {
+                        stage('Linux - py37 - conanprev') {
                             environment {
-                                TOXENV = 'py39-conanprev'
+                                TOXENV = 'py37-conanprev'
                             }
                             steps {
                                 sh '''
@@ -248,9 +248,9 @@ pipeline {
                                 '''
                             }
                         }
-                        stage('Linux - py39 - conanprevprev') {
+                        stage('Linux - py37 - conanprevprev') {
                             environment {
-                                TOXENV = 'py39-conanprevprev'
+                                TOXENV = 'py37-conanprevprev'
                             }
                             steps {
                                 sh '''


### PR DESCRIPTION
- Mac is failing to install Python 3.9
- We don't use Python 3.9 on CCI, let's use Python 3.7