### PR TITLE
- conandata.yml reduce hook for 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Repository to develop **experimental** [Conan](https://conan.io) hooks for Conan
  * [Recipe linter](#recipe-linter)
  * [Non ASCII](#non-ascii)
  * [YAML linter](#yaml-linter)
+ * [Reduce conandata.yml](#reduce-conandata)
 
 
 ## Hook setup
@@ -185,6 +186,12 @@ in a recipe before exporting them (it runs in the `pre_export` hook), it can be
 really useful to check for typos.
 
 This hook requires additional dependencies to work: `pip install yamllint`.
+
+### [Reduce conandata.yml](hooks/hook_reduce_conandata.py)
+
+Same as KB-H031, but for conan 2.0.
+Reduces `conandata.yml` files, keeping only entry for the current package version.
+It only helps to avoid generation of extra recipe revisions in case of adding new versions.
 
 ## License
 

--- a/hooks/hook_reduce_conandata.py
+++ b/hooks/hook_reduce_conandata.py
@@ -1,0 +1,31 @@
+import os
+import yaml
+
+from conan.tools.files import load, save
+
+
+def load_yml(conanfile, path):
+    if os.path.isfile(path):
+        return yaml.safe_load(load(conanfile, path))
+    return None
+
+
+def post_export(output, conanfile, conanfile_path, reference, **kwargs):
+    export_folder_path = os.path.dirname(conanfile_path)
+
+    conandata_path = os.path.join(export_folder_path, "conandata.yml")
+    version = str(conanfile.version)
+
+    conandata_yml = load_yml(conanfile, conandata_path)
+    if not conandata_yml:
+        return
+    info = {}
+    for entry in conandata_yml:
+        if version not in conandata_yml[entry]:
+            continue
+        info[entry] = {}
+        info[entry][version] = conandata_yml[entry][version]
+    output.info("Saving conandata.yml: {}".format(info))
+    new_conandata_yml = yaml.safe_dump(info, default_flow_style=False)
+    output.info("New conandata.yml contents: {}".format(new_conandata_yml))
+    save(conanfile, conandata_path, new_conandata_yml)


### PR DESCRIPTION
generates the same RREV as v1:
```
fmt/8.1.1: Exported revision: f0c7ec2a07a4a1ba80bfc2e4cbf18a43

f0c7ec2a07a4a1ba80bfc2e4cbf18a43
```
with v2:
```
←[1m←[32mExported recipe: fmt/8.1.1#f0c7ec2a07a4a1ba80bfc2e4cbf18a43 (2022-06-22 11:12:33 UTC)←[0m 
```