### PR TITLE
[conan-center] KB-H050 Allow NSS package as shared by default

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -906,6 +906,7 @@ def post_export(output, conanfile, conanfile_path, reference, **kwargs):
             "pdal",
             "tbb",
             "vulkan-loader",
+            "nss",
         )
         if conanfile.name in allowlist:
             out.info("'{}' is part of the allowlist, skipping.".format(conanfile.name))


### PR DESCRIPTION
Related to https://github.com/conan-io/conan-center-index/pull/11395

The static option does not word for NSS package. Let's keep shared=True by default.

/cc @ericLemanissier @jwillikers