### PR TITLE
[conan-center] The custom method _is_msvc is no longer needed

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -81,7 +81,7 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H069": "TEST PACKAGE - NO DEFAULT OPTIONS",
              "KB-H070": "MANDATORY SETTINGS",
              "KB-H071": "INCLUDE PATH DOES NOT EXIST",
-             "KB-H072": "MSVC TOOLS",
+             "KB-H072": "MICROSOFT TOOLS",
              }
 
 

--- a/tests/test_hooks/conan-center/test_microsoft_tools.py
+++ b/tests/test_hooks/conan-center/test_microsoft_tools.py
@@ -51,10 +51,10 @@ class MSVCToolsTests(ConanClientTestCase):
     def test_custom_is_msvc_not_allowed(self):
         tools.save('conanfile.py', content=self.conanfile_outdated)
         output = self.conan(['create', '.', 'name/version@user/channel'])
-        self.assertIn("WARN: [MSVC TOOLS (KB-H072)]", output)
+        self.assertIn("WARN: [MICROSOFT TOOLS (KB-H072)]", output)
         self.assertIn("conanfile.py:12 Custom deprecated functions detected. Use of '_is_msvc' is outdated, replace by 'conan.tools.microsoft.is_msvc'.", output)
 
     def test_tools_msvc(self):
         tools.save('conanfile.py', content=self.conanfile_modern)
         output = self.conan(['create', '.', 'name/version@user/channel'])
-        self.assertIn("[MSVC TOOLS (KB-H072)] OK", output)
+        self.assertIn("[MICROSOFT TOOLS (KB-H072)] OK", output)

--- a/tests/test_hooks/conan-center/test_msvc_tools.py
+++ b/tests/test_hooks/conan-center/test_msvc_tools.py
@@ -1,0 +1,60 @@
+import os
+import textwrap
+
+from conans import tools
+
+from tests.utils.test_cases.conan_client import ConanClientTestCase
+
+
+class MSVCToolsTests(ConanClientTestCase):
+    conanfile_outdated = textwrap.dedent("""\
+        import os
+        from conans import ConanFile, tools
+
+        class AConan(ConanFile):
+            url = "fake_url.com"
+            license = "fake_license"
+            description = "whatever"
+            settings = "os", "arch", "build_type", "compiler"
+
+            @property
+            def _is_msvc(self):
+                return self.settings.compiler == "Visual Studio" or self.settings.compiler == "msvc"
+
+            def validate(self):
+                if self._is_msvc:
+                    self.output.info("It's MSVC")
+        """)
+
+    conanfile_modern = textwrap.dedent("""\
+            import os
+            from conan import ConanFile
+            from conan.tools.microsoft import is_msvc
+
+            class AConan(ConanFile):
+                url = "fake_url.com"
+                license = "fake_license"
+                description = "whatever"
+                settings = "os", "arch", "build_type", "compiler"
+
+                def validate(self):
+                    if is_msvc(self):
+                        self.output.info("It's MSVC")
+            """)
+
+    def _get_environ(self, **kwargs):
+        kwargs = super(MSVCToolsTests, self)._get_environ(**kwargs)
+        kwargs.update({'CONAN_HOOKS': os.path.join(os.path.dirname(__file__), '..', '..', '..',
+                                                   'hooks', 'conan-center')})
+        return kwargs
+
+    def test_custom_is_msvc_not_allowed(self):
+        tools.save('conanfile.py', content=self.conanfile_outdated)
+        output = self.conan(['create', '.', 'name/version@user/channel'])
+        self.assertIn("WARN: [MSVC TOOLS (KB-H072)]", output)
+        self.assertIn("conanfile.py:12 Custom deprecated functions detected. Use of '_is_msvc' is outdated, replace by 'conan.tools.microsoft.is_msvc'.", output)
+
+    def test_tools_msvc(self):
+        tools.save('conanfile.py', content=self.conanfile_modern)
+        output = self.conan(['create', '.', 'name/version@user/channel'])
+        self.assertIn("[MSVC TOOLS (KB-H072)] OK", output)


### PR DESCRIPTION
New Conan Center hook entry: 72 - MSVC TOOLS

The first step is suggesting the deprecation of `_is_msvc`.

Related to #440 

/cc @prince-chrismc 


WIKI INFO:

**#KB-H072: "MICROSOFT TOOLS"**

Some custom and popular methods involving Microsoft compiler has been adopted to Conan client. Use only methods provided by `conan.tools.microsoft` import instead of adopting custom methods, they are better maintained and easier to update. 
