### PR TITLE
[conan-center] Accept self.info.clear() as header-only

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1357,7 +1357,8 @@ def _is_recipe_header_only(conanfile):
     package_id_method = getattr(conanfile, "package_id")
     header_only_id = "self.info.header_only()" in inspect.getsource(package_id_method)
     settings_clear = "self.info.settings.clear()" in inspect.getsource(package_id_method)
-    return header_only_id or without_settings or settings_clear
+    info_clear = "self.info.clear()" in inspect.getsource(package_id_method)
+    return header_only_id or without_settings or settings_clear or info_clear
 
 
 def _get_settings(conanfile):


### PR DESCRIPTION
According to the migration guide, the `self.info.clear()` should be used to identify header-only recipes.


Documentation https://docs.conan.io/en/latest/migrating_to_2.0/recipes.html#the-package-id-method