### PR TITLE
Fix build_modules-related typo in conan-center.py

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1188,7 +1188,7 @@ def post_package_info(output, conanfile, reference, **kwargs):
         else:
             out.warn("cpp_info.build_modules is not a dictionary")
         for component_name, component in conanfile.cpp_info.components.items():
-            if isinstance(conanfile.cpp_info.build_modules, dict):
+            if isinstance(component.build_modules, dict):
                 build_modules.extend(component.build_modules["cmake_find_package"])
                 build_modules.extend(component.build_modules["cmake_find_package_multi"])
             else:


### PR DESCRIPTION
This fixes a typo introduced in https://github.com/conan-io/hooks/pull/439

In the original version, the same condition was used for the global and the per-component type check. This PR fixes the per-component condition.

The typo causes an error like this:
```
[HOOK - conan-center.py] post_package_info(): ERROR: [CMAKE FILE NOT IN BUILD FOLDERS (KB-H019)] Exception raised from hook: list indices must be integers or slices, not str (type=TypeError) (https://github.com/conan-io/conan-center-index/blob/master/docs/error_knowledge_base.md#KB-H019) 
ERROR: 
	ConanException: [HOOK - conan-center.py] post_package_info(): list indices must be integers or slices, not str
```

This error is currently blocking me from merging this PR: https://github.com/conan-io/conan-center-index/pull/12189