### PR TITLE
[conan-center] Allow moltenvk shared by default

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -901,15 +901,16 @@ def post_export(output, conanfile, conanfile_path, reference, **kwargs):
     @run_test("KB-H050", output)
     def test(out):
         allowlist = (
+            "glib",
             "libgphoto2",
+            "moltenvk",
+            "nss",
             "onetbb",
             "opencl-icd-loader",
             "paho-mqtt-c",
             "pdal",
             "tbb",
             "vulkan-loader",
-            "nss",
-            "glib"
         )
         if conanfile.name in allowlist:
             out.info("'{}' is part of the allowlist, skipping.".format(conanfile.name))


### PR DESCRIPTION
- MoltenVK shared can be either:
  -  dynamically linked (and vulkan-loader must not be linked)
  - discovered & loaded at runtime as a vulkan ICD (Installable Client Drivers: see https://vulkan.lunarg.com/doc/view/1.2.162.1/windows/loader_and_layer_interface.html#user-content-vulkan-installable-client-driver-interface-with-the-loader for example) by vulkan-loader (more precisely by `vkCreateInstance` which is the very first function called to initiate a vulkan instance).

- MoltenVK static can only be statically linked (and vulkan-loader must not be linked), so it's less versatile.

Therefore I advice to provide MoltenVK shared by default in conan-center.