### PR TITLE
[conan-center] Pylint should not be skipped from conanfile

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -883,13 +883,11 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
                 if re.search(pattern, content):
                     out.error(f"Pylint can not be skipped, remove '#pylint' line from '{path}'")
 
-        _check_conanfile_content(conanfile_content, "conanfile.py")
-        test_package_path = os.path.join(os.path.dirname(conanfile_path), "test_package", "conanfile.py")
-        test_v1_package_path = os.path.join(os.path.dirname(conanfile_path), "test_v1_package", "conanfile.py")
-        for test_package in [test_package_path, test_v1_package_path]:
-            if os.path.exists(test_package):
-                test_package_content = tools.load(test_package)
-                _check_conanfile_content(test_package_content, test_package)
+        recipe_folder = os.path.dirname(conanfile_path)
+        recipes = _get_files_following_patterns(recipe_folder, "conanfile*.py")
+        for recipe in recipes:
+            recipe_content = tools.load(recipe)
+            _check_conanfile_content(recipe_content, recipe)
 
 
 @raise_if_error_output

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -884,13 +884,12 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
                     out.error(f"Pylint can not be skipped, remove '#pylint' line from '{path}'")
 
         _check_conanfile_content(conanfile_content, "conanfile.py")
-
-        # INFO: When Test V1 package is present, test package prepared for Conan 2.0, should not skip pylint
         test_package_path = os.path.join(os.path.dirname(conanfile_path), "test_package", "conanfile.py")
         test_v1_package_path = os.path.join(os.path.dirname(conanfile_path), "test_v1_package", "conanfile.py")
-        if os.path.exists(test_package_path) and os.path.exists(test_v1_package_path):
-            test_package_content = tools.load(test_package_path)
-            _check_conanfile_content(test_package_content, test_package_path)
+        for test_package in [test_package_path, test_v1_package_path]:
+            if os.path.exists(test_package):
+                test_package_content = tools.load(test_package)
+                _check_conanfile_content(test_package_content, test_package)
 
 
 @raise_if_error_output

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -81,6 +81,7 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H069": "TEST PACKAGE - NO DEFAULT OPTIONS",
              "KB-H070": "MANDATORY SETTINGS",
              "KB-H071": "INCLUDE PATH DOES NOT EXIST",
+             "KB-H072": "PYLINT EXECUTION",
              }
 
 
@@ -873,6 +874,23 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
                          "values and use 'package_id(self)' method to manage the package ID.".format("', '".join(missing)))
         else:
             out.warn("No 'settings' detected in your conanfile.py. Add 'settings' attribute and use 'package_id(self)' method to manage the package ID.")
+
+    @run_test("KB-H072", output)
+    def test(out):
+        def _check_conanfile_content(content, path):
+            patterns = [r'#\s*pylint\s*:\s*skip-file\s*', '#\s*pylint\s*:\s*disable-all\s*', '#\s*pylint\s*:\s*disable=']
+            for pattern in patterns:
+                if re.search(pattern, content):
+                    out.error(f"Pylint can not be skipped, remove '#pylint' line from '{path}'")
+
+        _check_conanfile_content(conanfile_content, "conanfile.py")
+
+        # INFO: When Test V1 package is present, test package prepared for Conan 2.0, should not skip pylint
+        test_package_path = os.path.join(os.path.dirname(conanfile_path), "test_package", "conanfile.py")
+        test_v1_package_path = os.path.join(os.path.dirname(conanfile_path), "test_v1_package", "conanfile.py")
+        if os.path.exists(test_package_path) and os.path.exists(test_v1_package_path):
+            test_package_content = tools.load(test_package_path)
+            _check_conanfile_content(test_package_content, test_package_path)
 
 
 @raise_if_error_output

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -884,10 +884,11 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
                     out.error(f"Pylint can not be skipped, remove '#pylint' line from '{path}'")
 
         recipe_folder = os.path.dirname(conanfile_path)
-        recipes = _get_files_following_patterns(recipe_folder, ["conanfile*.py"])
+        recipes = _get_files_following_patterns(recipe_folder, [r"conanfile.py", ])
         for recipe in recipes:
-            recipe_content = tools.load(recipe)
-            _check_conanfile_content(recipe_content, recipe)
+            recipe_path = os.path.join(recipe_folder, recipe)
+            recipe_content = tools.load(recipe_path)
+            _check_conanfile_content(recipe_content, recipe_path)
 
 
 @raise_if_error_output

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -884,7 +884,7 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
                     out.error(f"Pylint can not be skipped, remove '#pylint' line from '{path}'")
 
         recipe_folder = os.path.dirname(conanfile_path)
-        recipes = _get_files_following_patterns(recipe_folder, "conanfile*.py")
+        recipes = _get_files_following_patterns(recipe_folder, ["conanfile*.py"])
         for recipe in recipes:
             recipe_content = tools.load(recipe)
             _check_conanfile_content(recipe_content, recipe)

--- a/tests/test_hooks/conan-center/test_skip_pylint.py
+++ b/tests/test_hooks/conan-center/test_skip_pylint.py
@@ -15,6 +15,8 @@ class TestSkipPylint(ConanClientTestCase):
         return kwargs
 
     def test_trivial_ok(self):
+        """No error expected for regular conan recipe without pylint attribute
+        """
         tools.save("conanfile.py", content=textwrap.dedent("""\
             from conan import ConanFile
 
@@ -25,6 +27,9 @@ class TestSkipPylint(ConanClientTestCase):
         self.assertIn("[PYLINT EXECUTION (KB-H072)] OK", output)
 
     def test_pylint_comment(self):
+        """Pylint should be classified when is a command in middle of the code, or
+           an attribute to its client
+        """
         tools.save("conanfile.py", content=textwrap.dedent("""\
             from conan import ConanFile
 
@@ -36,6 +41,8 @@ class TestSkipPylint(ConanClientTestCase):
         self.assertIn("[PYLINT EXECUTION (KB-H072)] OK", output)
 
     def test_pylint_skip_file(self):
+        """Pytlint skip-file should not be allowed when found in a recipe
+        """
         tools.save("conanfile.py", content=textwrap.dedent("""\
             # pylint: skip-file
             from conan import ConanFile
@@ -47,6 +54,8 @@ class TestSkipPylint(ConanClientTestCase):
         self.assertIn("ERROR: [PYLINT EXECUTION (KB-H072)] Pylint can not be skipped, remove '#pylint' line from", output)
 
     def test_pylint_disable_all(self):
+        """Legacy pylint disable-all (previous form of skip-file) should not be allowed
+        """
         tools.save("conanfile.py", content=textwrap.dedent("""\
                     #pylint: disable-all
                     from conan import ConanFile
@@ -58,6 +67,8 @@ class TestSkipPylint(ConanClientTestCase):
         self.assertIn("ERROR: [PYLINT EXECUTION (KB-H072)] Pylint can not be skipped, remove '#pylint' line from", output)
 
     def test_pylint_disable_locally(self):
+        """Partial Pylint disable should not be allowed
+        """
         tools.save("conanfile.py", content=textwrap.dedent("""\
                     # pylint : disable=locally-disabled, multiple-statements, fixme, line-too-long
                     from conan import ConanFile
@@ -69,6 +80,8 @@ class TestSkipPylint(ConanClientTestCase):
         self.assertIn("ERROR: [PYLINT EXECUTION (KB-H072)] Pylint can not be skipped, remove '#pylint' line from", output)
 
     def test_pylint_test_package_alone(self):
+        """Test package should be scanned by pylint always
+        """
         tools.save("conanfile.py", content=textwrap.dedent("""\
                     from conan import ConanFile
                     class AConan(ConanFile):
@@ -84,6 +97,8 @@ class TestSkipPylint(ConanClientTestCase):
         self.assertIn("ERROR: [PYLINT EXECUTION (KB-H072)] Pylint can not be skipped, remove '#pylint' line from", output)
 
     def test_pylint_test_v1_package(self):
+        """Test V1 package should be scanned by pylint always
+        """
         tools.save("conanfile.py", content=textwrap.dedent("""\
                     from conan import ConanFile
                     class AConan(ConanFile):

--- a/tests/test_hooks/conan-center/test_skip_pylint.py
+++ b/tests/test_hooks/conan-center/test_skip_pylint.py
@@ -1,0 +1,104 @@
+import os
+import textwrap
+
+from conans import tools
+
+from tests.utils.test_cases.conan_client import ConanClientTestCase
+
+
+class TestSkipPylint(ConanClientTestCase):
+
+    def _get_environ(self, **kwargs):
+        kwargs = super(TestSkipPylint, self)._get_environ(**kwargs)
+        kwargs.update({"CONAN_HOOKS": os.path.join(os.path.dirname(__file__), "..", "..", "..",
+                                                   "hooks", "conan-center")})
+        return kwargs
+
+    def test_trivial_ok(self):
+        tools.save("conanfile.py", content=textwrap.dedent("""\
+            from conan import ConanFile
+
+            class AConan(ConanFile):
+                pass
+            """))
+        output = self.conan(["export", ".", "name/version@user/channel"])
+        self.assertIn("[PYLINT EXECUTION (KB-H072)] OK", output)
+
+    def test_pylint_comment(self):
+        tools.save("conanfile.py", content=textwrap.dedent("""\
+            from conan import ConanFile
+
+            class AConan(ConanFile):
+                def configure(self):
+                    pass #pylint: this is a comment
+            """))
+        output = self.conan(["export", ".", "name/version@user/channel"])
+        self.assertIn("[PYLINT EXECUTION (KB-H072)] OK", output)
+
+    def test_pylint_skip_file(self):
+        tools.save("conanfile.py", content=textwrap.dedent("""\
+            # pylint: skip-file
+            from conan import ConanFile
+            
+            class AConan(ConanFile):
+                pass
+            """))
+        output = self.conan(["export", ".", "name/version@user/channel"])
+        self.assertIn("ERROR: [PYLINT EXECUTION (KB-H072)] Pylint can not be skipped", output)
+
+    def test_pylint_disable_all(self):
+        tools.save("conanfile.py", content=textwrap.dedent("""\
+                    #pylint: disable-all
+                    from conan import ConanFile
+
+                    class AConan(ConanFile):
+                        pass
+                    """))
+        output = self.conan(["export", ".", "name/version@user/channel"])
+        self.assertIn("ERROR: [PYLINT EXECUTION (KB-H072)] Pylint can not be skipped", output)
+
+    def test_pylint_disable_locally(self):
+        tools.save("conanfile.py", content=textwrap.dedent("""\
+                    # pylint : disable=locally-disabled, multiple-statements, fixme, line-too-long
+                    from conan import ConanFile
+
+                    class AConan(ConanFile):
+                        pass
+                    """))
+        output = self.conan(["export", ".", "name/version@user/channel"])
+        self.assertIn("ERROR: [PYLINT EXECUTION (KB-H072)] Pylint can not be skipped", output)
+
+    def test_pylint_test_package_alone(self):
+        tools.save("conanfile.py", content=textwrap.dedent("""\
+                    from conan import ConanFile
+                    class AConan(ConanFile):
+                        pass
+                    """))
+        tools.save("test_package/conanfile.py", content=textwrap.dedent("""\
+                    #pylint: skip-file
+                    from conan import ConanFile
+                    class AConan(ConanFile):
+                        pass
+                    """))
+        output = self.conan(["export", ".", "name/version@user/channel"])
+        self.assertIn("[PYLINT EXECUTION (KB-H072)] OK", output)
+
+    def test_pylint_test_v1_package(self):
+        tools.save("conanfile.py", content=textwrap.dedent("""\
+                    from conan import ConanFile
+                    class AConan(ConanFile):
+                        pass
+                    """))
+        tools.save("test_package/conanfile.py", content=textwrap.dedent("""\
+                    #pylint: skip-file
+                    from conan import ConanFile
+                    class AConan(ConanFile):
+                        pass
+                    """))
+        tools.save("test_v1_package/conanfile.py", content=textwrap.dedent("""\
+                    from conan import ConanFile
+                    class AConan(ConanFile):
+                        pass
+                    """))
+        output = self.conan(["export", ".", "name/version@user/channel"])
+        self.assertIn("ERROR: [PYLINT EXECUTION (KB-H072)] Pylint can not be skipped", output)

--- a/tests/test_hooks/conan-center/test_skip_pylint.py
+++ b/tests/test_hooks/conan-center/test_skip_pylint.py
@@ -81,7 +81,7 @@ class TestSkipPylint(ConanClientTestCase):
                         pass
                     """))
         output = self.conan(["export", ".", "name/version@user/channel"])
-        self.assertIn("[PYLINT EXECUTION (KB-H072)] OK", output)
+        self.assertIn("ERROR: [PYLINT EXECUTION (KB-H072)] Pylint can not be skipped", output)
 
     def test_pylint_test_v1_package(self):
         tools.save("conanfile.py", content=textwrap.dedent("""\
@@ -90,12 +90,12 @@ class TestSkipPylint(ConanClientTestCase):
                         pass
                     """))
         tools.save("test_package/conanfile.py", content=textwrap.dedent("""\
-                    #pylint: skip-file
                     from conan import ConanFile
                     class AConan(ConanFile):
                         pass
                     """))
         tools.save("test_v1_package/conanfile.py", content=textwrap.dedent("""\
+                    #pylint: skip-file
                     from conan import ConanFile
                     class AConan(ConanFile):
                         pass

--- a/tests/test_hooks/conan-center/test_skip_pylint.py
+++ b/tests/test_hooks/conan-center/test_skip_pylint.py
@@ -44,7 +44,7 @@ class TestSkipPylint(ConanClientTestCase):
                 pass
             """))
         output = self.conan(["export", ".", "name/version@user/channel"])
-        self.assertIn("ERROR: [PYLINT EXECUTION (KB-H072)] Pylint can not be skipped", output)
+        self.assertIn("ERROR: [PYLINT EXECUTION (KB-H072)] Pylint can not be skipped, remove '#pylint' line from", output)
 
     def test_pylint_disable_all(self):
         tools.save("conanfile.py", content=textwrap.dedent("""\
@@ -55,7 +55,7 @@ class TestSkipPylint(ConanClientTestCase):
                         pass
                     """))
         output = self.conan(["export", ".", "name/version@user/channel"])
-        self.assertIn("ERROR: [PYLINT EXECUTION (KB-H072)] Pylint can not be skipped", output)
+        self.assertIn("ERROR: [PYLINT EXECUTION (KB-H072)] Pylint can not be skipped, remove '#pylint' line from", output)
 
     def test_pylint_disable_locally(self):
         tools.save("conanfile.py", content=textwrap.dedent("""\
@@ -66,7 +66,7 @@ class TestSkipPylint(ConanClientTestCase):
                         pass
                     """))
         output = self.conan(["export", ".", "name/version@user/channel"])
-        self.assertIn("ERROR: [PYLINT EXECUTION (KB-H072)] Pylint can not be skipped", output)
+        self.assertIn("ERROR: [PYLINT EXECUTION (KB-H072)] Pylint can not be skipped, remove '#pylint' line from", output)
 
     def test_pylint_test_package_alone(self):
         tools.save("conanfile.py", content=textwrap.dedent("""\
@@ -81,7 +81,7 @@ class TestSkipPylint(ConanClientTestCase):
                         pass
                     """))
         output = self.conan(["export", ".", "name/version@user/channel"])
-        self.assertIn("ERROR: [PYLINT EXECUTION (KB-H072)] Pylint can not be skipped", output)
+        self.assertIn("ERROR: [PYLINT EXECUTION (KB-H072)] Pylint can not be skipped, remove '#pylint' line from", output)
 
     def test_pylint_test_v1_package(self):
         tools.save("conanfile.py", content=textwrap.dedent("""\
@@ -101,4 +101,4 @@ class TestSkipPylint(ConanClientTestCase):
                         pass
                     """))
         output = self.conan(["export", ".", "name/version@user/channel"])
-        self.assertIn("ERROR: [PYLINT EXECUTION (KB-H072)] Pylint can not be skipped", output)
+        self.assertIn("ERROR: [PYLINT EXECUTION (KB-H072)] Pylint can not be skipped, remove '#pylint' line from", output)


### PR DESCRIPTION
Based on CCI activity. As humans, we can fail when reviewing it, pylint will skip silently.


Wiki:


#### **<a name="KB-H072">#KB-H072</a>: "PYLINT EXECUTION"**

Pylint is executed by default over all `conanfile.py` in Conan Center Index and it should not be skipped. It's an important tool which help us keeping a standard level of acceptance, otherwise, it would be incredible hard to review all recipes keeping the same standard level.
