### PR TITLE
[conan-center] KB-H073 Test v1 package folder

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -82,6 +82,7 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H070": "MANDATORY SETTINGS",
              "KB-H071": "INCLUDE PATH DOES NOT EXIST",
              "KB-H072": "PYLINT EXECUTION",
+             "KB-H073": "TEST V1 PACKAGE FOLDER",
              }
 
 
@@ -889,6 +890,20 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
             recipe_path = os.path.join(recipe_folder, recipe)
             recipe_content = tools.load(recipe_path)
             _check_conanfile_content(recipe_content, recipe_path)
+
+    @run_test("KB-H073", output)
+    def test(out):
+        dir_path = os.path.dirname(conanfile_path)
+        test_package_conanfile_path = os.path.join(dir_path, "test_package", "conanfile.py")
+        test_v1_package_path = os.path.join(dir_path, "test_v1_package")
+        if os.path.isfile(test_package_conanfile_path):
+            try:
+                test_conanfile = tools.load(test_package_conanfile_path)
+                if ("VirtualRunEnv" in test_conanfile or "self.cpp.build" in test_conanfile) and \
+                        not os.path.exists(test_v1_package_path):
+                    out.error("The test_package seems be prepared for Conan v2, but test_v1_package is missing.")
+            except Exception as error:
+                out.warn(f"Invalid conanfile: {error}")
 
 
 @raise_if_error_output

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -896,14 +896,18 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
         dir_path = os.path.dirname(conanfile_path)
         test_package_conanfile_path = os.path.join(dir_path, "test_package", "conanfile.py")
         test_v1_package_path = os.path.join(dir_path, "test_v1_package")
+        test_v1_package_conanfile_path = os.path.join(test_v1_package_path, "conanfile.py")
+        content = None
         if os.path.isfile(test_package_conanfile_path):
             try:
-                test_conanfile = tools.load(test_package_conanfile_path)
-                if ("VirtualRunEnv" in test_conanfile or "self.cpp.build" in test_conanfile) and \
-                        not os.path.exists(test_v1_package_path):
-                    out.error("The test_package seems be prepared for Conan v2, but test_v1_package is missing.")
+                content = tools.load(test_package_conanfile_path)
             except Exception as error:
                 out.warn(f"Invalid conanfile: {error}")
+        if content and ("VirtualRunEnv" in content or "self.cpp.build" in content):
+            if not os.path.exists(test_v1_package_path):
+                out.error("The test_package seems be prepared for Conan v2, but test_v1_package is missing.")
+            elif not os.path.isfile(test_v1_package_conanfile_path):
+                out.error("There is no 'conanfile.py' in 'test_v1_package' folder")
 
 
 @raise_if_error_output

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -903,7 +903,7 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
                 content = tools.load(test_package_conanfile_path)
             except Exception as error:
                 out.warn(f"Invalid conanfile: {error}")
-        if content and ("VirtualRunEnv" in content or "self.cpp.build" in content):
+        if content and "self.tested_reference_str" in content:
             if not os.path.exists(test_v1_package_path):
                 out.error("The test_package seems be prepared for Conan v2, but test_v1_package is missing.")
             elif not os.path.isfile(test_v1_package_conanfile_path):

--- a/tests/test_hooks/conan-center/test_missing_test_v1_package.py
+++ b/tests/test_hooks/conan-center/test_missing_test_v1_package.py
@@ -77,9 +77,17 @@ class TestMissingTestV1Package(ConanClientTestCase):
         output = self.conan(['export', '.', 'name/version@user/channel'])
         self.assertIn("[TEST V1 PACKAGE FOLDER (KB-H073)] OK", output)
 
-    def test_missing_legacy_test_package(self):
+    def test_missing_test_v1_package_folder(self):
         tools.save('conanfile.py', content=self.conanfile)
         tools.save('test_package/conanfile.py', content=self.test_package_conanfile)
         output = self.conan(['export', '.', 'name/version@user/channel'])
         self.assertIn("ERROR: [TEST V1 PACKAGE FOLDER (KB-H073)] The test_package seems be prepared for Conan v2, "
                       "but test_v1_package is missing.", output)
+
+    def test_missing_test_v1_package_conanfile(self):
+        tools.save('conanfile.py', content=self.conanfile)
+        tools.save('test_package/conanfile.py', content=self.test_package_conanfile)
+        tools.mkdir('test_v1_package')
+        output = self.conan(['export', '.', 'name/version@user/channel'])
+        self.assertIn("ERROR: [TEST V1 PACKAGE FOLDER (KB-H073)] There is no 'conanfile.py' in 'test_v1_package'"
+                      " folder", output)

--- a/tests/test_hooks/conan-center/test_missing_test_v1_package.py
+++ b/tests/test_hooks/conan-center/test_missing_test_v1_package.py
@@ -1,0 +1,85 @@
+import os
+import textwrap
+
+from conans import tools
+
+from tests.utils.test_cases.conan_client import ConanClientTestCase
+
+
+class TestMissingTestV1Package(ConanClientTestCase):
+    conanfile = textwrap.dedent("""\
+        from conan import ConanFile
+        class AConan(ConanFile):
+            topics = ("foobar",)
+            pass
+        """)
+
+    test_package_conanfile = textwrap.dedent("""\
+            from conan import ConanFile
+            from conan.tools.cmake import CMake, cmake_layout
+            from conan.tools.build import can_run
+
+            class TestPackageConan(ConanFile):
+                settings = "os", "arch", "compiler", "build_type"
+                generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+                test_type = "explicit"
+            
+                def requirements(self):
+                    self.requires(self.tested_reference_str)
+            
+                def layout(self):
+                    cmake_layout(self)
+            
+                def build(self):
+                    cmake = CMake(self)
+                    cmake.configure()
+                    cmake.build()
+            
+                def test(self):
+                    if can_run(self):
+                        bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+                        self.run(bin_path, env="conanrun")
+                
+            """)
+
+    test_v1_package_conanfile = textwrap.dedent("""\
+            from conans import ConanFile, CMake
+            from conan.tools.build import cross_building
+            import os
+            
+            
+            # legacy validation with Conan 1.x
+            class TestPackageV1Conan(ConanFile):
+                settings = "os", "arch", "compiler", "build_type"
+                generators = "cmake", "cmake_find_package_multi"
+            
+                def build(self):
+                    cmake = CMake(self)
+                    cmake.configure()
+                    cmake.build()
+            
+                def test(self):
+                    if not cross_building(self):
+                        bin_path = os.path.join("bin", "test_package")
+                        self.run(bin_path, run_environment=True)
+            """)
+
+    def _get_environ(self, **kwargs):
+        kwargs = super(TestMissingTestV1Package, self)._get_environ(**kwargs)
+        kwargs.update({'CONAN_HOOKS': os.path.join(os.path.dirname(__file__), '..', '..', '..',
+                                                   'hooks', 'conan-center')})
+        return kwargs
+
+    def test_valid_folder_structure(self):
+        tools.save('conanfile.py', content=self.conanfile)
+        tools.save('test_package/conanfile.py', content=self.test_package_conanfile)
+        tools.save('test_v1_package/conanfile.py', content=self.test_v1_package_conanfile)
+        output = self.conan(['export', '.', 'name/version@user/channel'])
+        self.assertIn("[TEST V1 PACKAGE FOLDER (KB-H073)] OK", output)
+
+    def test_missing_legacy_test_package(self):
+        tools.save('conanfile.py', content=self.conanfile)
+        tools.save('test_package/conanfile.py', content=self.test_package_conanfile)
+        output = self.conan(['export', '.', 'name/version@user/channel'])
+        self.assertIn("ERROR: [TEST V1 PACKAGE FOLDER (KB-H073)] The test_package seems be prepared for Conan v2, "
+                      "but test_v1_package is missing.", output)


### PR DESCRIPTION
As users are porting Conan v2 package in CCI, but mostly forget to add test_v1_package, this hook should help them:

- When test_package is ported to support Conan v2, test_v1_package must be present
- test_v1_package must contain a conanfile.py
- It will be considered an error


closes #450 

#### **<a name="KB-H073">#KB-H073</a>: "TEST V1 PACKAGE FOLDER"**

The legacy content in test_package should not be removed, instead, rename that folder to test_v1_package and create a new test_folder following the [file structure](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md#recipe-files-structure) related to Conan v2 and v1 compatibility. Also, you can obtain good example on [templates package](https://github.com/conan-io/conan-center-index/tree/master/docs/package_templates) about Conan v2 test_package.