### PR TITLE
[conan-center] Accept self.settings.rm_safe

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1012,8 +1012,8 @@ def post_source(output, conanfile, conanfile_path, **kwargs):
             low = conanfile_content.lower()
 
             if conanfile.settings.get_safe("compiler") and \
-                ("del self.settings.compiler.libcxx" not in low or \
-                 'self.settings.rm_safe("compiler.libcxx")' not in low or \
+                ("del self.settings.compiler.libcxx" not in low and \
+                 'self.settings.rm_safe("compiler.libcxx")' not in low and \
                  "self.settings.rm_safe('compiler.libcxx')" not in low):
                 out.error("Can't detect C++ source files but recipe does not remove "
                           "'self.settings.compiler.libcxx'")
@@ -1024,8 +1024,8 @@ def post_source(output, conanfile, conanfile_path, **kwargs):
             conanfile_content = tools.load(conanfile_path)
             low = conanfile_content.lower()
             if conanfile.settings.get_safe("compiler") and \
-                ("del self.settings.compiler.cppstd" not in low or \
-                 'self.settings.rm_safe("compiler.cppstd")' not in low or \
+                ("del self.settings.compiler.cppstd" not in low and \
+                 'self.settings.rm_safe("compiler.cppstd")' not in low and \
                  "self.settings.rm_safe('compiler.cppstd')" not in low):
                 out.error("Can't detect C++ source files but recipe does not remove "
                           "'self.settings.compiler.cppstd'")

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1011,7 +1011,10 @@ def post_source(output, conanfile, conanfile_path, **kwargs):
             conanfile_content = tools.load(conanfile_path)
             low = conanfile_content.lower()
 
-            if conanfile.settings.get_safe("compiler") and "del self.settings.compiler.libcxx" not in low:
+            if conanfile.settings.get_safe("compiler") and \
+                ("del self.settings.compiler.libcxx" not in low or \
+                 'self.settings.rm_safe("compiler.libcxx")' not in low or \
+                 "self.settings.rm_safe('compiler.libcxx')" not in low):
                 out.error("Can't detect C++ source files but recipe does not remove "
                           "'self.settings.compiler.libcxx'")
 
@@ -1020,7 +1023,10 @@ def post_source(output, conanfile, conanfile_path, **kwargs):
         if _is_pure_c():
             conanfile_content = tools.load(conanfile_path)
             low = conanfile_content.lower()
-            if conanfile.settings.get_safe("compiler") and "del self.settings.compiler.cppstd" not in low:
+            if conanfile.settings.get_safe("compiler") and \
+                ("del self.settings.compiler.cppstd" not in low or \
+                 'self.settings.rm_safe("compiler.cppstd")' not in low or \
+                 "self.settings.rm_safe('compiler.cppstd')" not in low):
                 out.error("Can't detect C++ source files but recipe does not remove "
                           "'self.settings.compiler.cppstd'")
 

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -430,6 +430,13 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("[LIBCXX MANAGEMENT (KB-H011)] OK", output)
         self.assertIn("[CPPSTD MANAGEMENT (KB-H022)] OK", output)
 
+        tools.save('conanfile.py', content=content.format(configure="""
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")"""))
+        output = self.conan(['create', '.', 'name/version@user/test'])
+        self.assertIn("[LIBCXX MANAGEMENT (KB-H011)] OK", output)
+        self.assertIn("[CPPSTD MANAGEMENT (KB-H022)] OK", output)
+
     def test_missing_attributes(self):
         conanfile = textwrap.dedent("""\
         from conans import ConanFile

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -430,12 +430,13 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("[LIBCXX MANAGEMENT (KB-H011)] OK", output)
         self.assertIn("[CPPSTD MANAGEMENT (KB-H022)] OK", output)
 
-        tools.save('conanfile.py', content=content.format(configure="""
-        self.settings.rm_safe("compiler.libcxx")
-        self.settings.rm_safe("compiler.cppstd")"""))
-        output = self.conan(['create', '.', 'name/version@user/test'])
-        self.assertIn("[LIBCXX MANAGEMENT (KB-H011)] OK", output)
-        self.assertIn("[CPPSTD MANAGEMENT (KB-H022)] OK", output)
+        if Version(conan_version).major >= "1.53":
+            tools.save('conanfile.py', content=content.format(configure="""
+            self.settings.rm_safe("compiler.libcxx")
+            self.settings.rm_safe("compiler.cppstd")"""))
+            output = self.conan(['create', '.', 'name/version@user/test'])
+            self.assertIn("[LIBCXX MANAGEMENT (KB-H011)] OK", output)
+            self.assertIn("[CPPSTD MANAGEMENT (KB-H022)] OK", output)
 
     def test_missing_attributes(self):
         conanfile = textwrap.dedent("""\


### PR DESCRIPTION
Since 1.52.0 is possible to use `self.settings.rm_safe` which should be an option against `del self.settings.compiler.xxx`

Docs: https://docs.conan.io/en/latest/changelog.html#oct-2022

closes #452