### PR TITLE
[conan-center] KB-H074 - check if there is at least one static lib when shared=False

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -83,6 +83,7 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H071": "INCLUDE PATH DOES NOT EXIST",
              "KB-H072": "PYLINT EXECUTION",
              "KB-H073": "TEST V1 PACKAGE FOLDER",
+             "KB-H074": "STATIC ARTIFACTS",
              }
 
 
@@ -1129,7 +1130,12 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
     @run_test("KB-H015", output)
     def test(out):
         if not _shared_files_well_managed(conanfile, conanfile.package_folder):
-            out.error("Package with 'shared' option did not contains any shared artifact")
+            out.error("Package with 'shared=True' option did not contain any shared artifact")
+
+    @run_test("KB-H074", output)
+    def test(out):
+        if not _static_files_well_managed(conanfile, conanfile.package_folder):
+            out.error("Package with 'shared=False' option did not contain any static artifact")
 
     @run_test("KB-H020", output)
     def test(out):
@@ -1327,6 +1333,19 @@ def _shared_files_well_managed(conanfile, folder):
         options_dict = {key: value for key, value in conanfile.options.items()}
     if shared_name in options_dict.keys() and options_dict[shared_name] == "True":
         if not _get_files_with_extensions(folder, shared_extensions):
+            return False
+    return True
+
+
+def _static_files_well_managed(conanfile, folder):
+    static_extensions = ["a", "lib"]
+    shared_name = "shared"
+    try:
+        options_dict = {key: value for key, value in conanfile.options.values.as_list()}
+    except Exception:
+        options_dict = {key: value for key, value in conanfile.options.items()}
+    if shared_name in options_dict.keys() and options_dict[shared_name] == "False":
+        if not _get_files_with_extensions(folder, static_extensions):
             return False
     return True
 

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -112,6 +112,7 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [PACKAGE LICENSE (KB-H012)] No 'licenses' folder found in package", output)
         self.assertIn("[DEFAULT PACKAGE LAYOUT (KB-H013)] OK", output)
         self.assertIn("[SHARED ARTIFACTS (KB-H015)] OK", output)
+        self.assertIn("[STATIC ARTIFACTS (KB-H074)] OK", output)
         self.assertIn("[EXPORT LICENSE (KB-H023)] OK", output)
         self.assertIn("ERROR: [TEST PACKAGE FOLDER (KB-H024)] There is no 'test_package' for this "
                       "recipe", output)
@@ -138,6 +139,7 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [PACKAGE LICENSE (KB-H012)] No 'licenses' folder found in package", output)
         self.assertIn("[DEFAULT PACKAGE LAYOUT (KB-H013)] OK", output)
         self.assertIn("[SHARED ARTIFACTS (KB-H015)] OK", output)
+        self.assertIn("[STATIC ARTIFACTS (KB-H074)] OK", output)
         self.assertIn("[EXPORT LICENSE (KB-H023)] OK", output)
         self.assertIn("ERROR: [TEST PACKAGE FOLDER (KB-H024)] There is no 'test_package' for this "
                       "recipe", output)
@@ -160,6 +162,7 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [PACKAGE LICENSE (KB-H012)] No 'licenses' folder found in package", output)
         self.assertIn("[DEFAULT PACKAGE LAYOUT (KB-H013)] OK", output)
         self.assertIn("[SHARED ARTIFACTS (KB-H015)] OK", output)
+        self.assertIn("[STATIC ARTIFACTS (KB-H074)] OK", output)
         self.assertIn("[EXPORT LICENSE (KB-H023)] OK", output)
         self.assertIn("ERROR: [TEST PACKAGE FOLDER (KB-H024)] There is no 'test_package' for this "
                       "recipe", output)
@@ -181,6 +184,7 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [PACKAGE LICENSE (KB-H012)] No 'licenses' folder found in package", output)
         self.assertIn("[DEFAULT PACKAGE LAYOUT (KB-H013)] OK", output)
         self.assertIn("[SHARED ARTIFACTS (KB-H015)] OK", output)
+        self.assertIn("[STATIC ARTIFACTS (KB-H074)] OK", output)
         self.assertIn("[EXPORT LICENSE (KB-H023)] OK", output)
         self.assertIn("ERROR: [TEST PACKAGE FOLDER (KB-H024)] There is no 'test_package' for this "
                       "recipe", output)
@@ -203,6 +207,7 @@ class ConanCenterTests(ConanClientTestCase):
         self.assertIn("ERROR: [PACKAGE LICENSE (KB-H012)] No 'licenses' folder found in package", output)
         self.assertIn("[DEFAULT PACKAGE LAYOUT (KB-H013)] OK", output)
         self.assertIn("[SHARED ARTIFACTS (KB-H015)] OK", output)
+        self.assertIn("[STATIC ARTIFACTS (KB-H074)] OK", output)
         self.assertIn("ERROR: [TEST PACKAGE FOLDER (KB-H024)] There is no 'test_package' for this "
                       "recipe", output)
         self.assertIn("[META LINES (KB-H025)] OK", output)


### PR DESCRIPTION
Migration to CMakeToolchain may break shared=False when upstream CMakeLists overrides BUILD_SHARED_LIBS as an option, or a CACHE variable. While https://github.com/conan-io/conan/pull/12401 may avoid most issues in conan >= 1.54.0, there might be some cases where it might still fail (like https://github.com/conan-io/conan-center-index/issues/14206).

So I propose this hook to check that `shared=False` is honored. It has the same logic than KB-H015 (check of shared artifacts). It's worth noting that check may not detect that static libs were not created if compiler is Visual Studio since static & import libs use the same extensions.