### PR TITLE
Skip post package for static library when building header only

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1340,10 +1340,13 @@ def _shared_files_well_managed(conanfile, folder):
 def _static_files_well_managed(conanfile, folder):
     static_extensions = ["a", "lib"]
     shared_name = "shared"
+    header_only_name = "header_only"
     try:
         options_dict = {key: value for key, value in conanfile.options.values.as_list()}
     except Exception:
         options_dict = {key: value for key, value in conanfile.options.items()}
+    if header_only_name in options_dict.keys() and options_dict[header_only_name] == "True":
+        return True
     if shared_name in options_dict.keys() and options_dict[shared_name] == "False":
         if not _get_files_with_extensions(folder, static_extensions):
             return False

--- a/tests/test_hooks/conan-center/test_header_only_extensions.py
+++ b/tests/test_hooks/conan-center/test_header_only_extensions.py
@@ -1,0 +1,119 @@
+import os
+import textwrap
+
+from conans import tools
+
+from tests.utils.test_cases.conan_client import ConanClientTestCase
+
+
+class TestHeaderOnlyExtensions(ConanClientTestCase):
+    """
+    False positive from https://github.com/conan-io/conan-center-index/pull/14330
+    post_package(): ERROR: [STATIC ARTIFACTS (KB-H074)] Package with 'shared=False' option did not contain any static artifact
+    """
+
+    conanfile = textwrap.dedent("""\
+        from conan import ConanFile
+        from conan.tools.files import get, copy
+        from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+        from conan.tools.layout import basic_layout
+        import os
+        
+        required_conan_version = ">=1.53.0"
+        
+        class MiniaudioConan(ConanFile):
+            name = "miniaudio"
+            settings = "os", "arch", "compiler", "build_type"
+            options = {
+                "shared": [True, False],
+                "fPIC": [True, False],
+                "header_only": [True, False],
+            }
+            default_options = {
+                "shared": False,
+                "fPIC": True,
+                "header_only": True,
+            }
+        
+            def config_options(self):
+                if self.settings.os == "Windows":
+                    del self.options.fPIC
+        
+            def configure(self):
+                if self.options.shared:
+                    self.options.rm_safe("fPIC")
+                self.settings.rm_safe("compiler.libcxx")
+                self.settings.rm_safe("compiler.cppstd")
+        
+            def layout(self):
+                if self.options.header_only:
+                    basic_layout(self, src_folder="src")
+                else:
+                    cmake_layout(self, src_folder="src")
+        
+            def package_id(self):
+                if self.options.header_only:
+                    self.info.clear()
+        
+            def generate(self):
+                if self.options.header_only:
+                    return
+        
+                tc = CMakeToolchain(self)
+                tc.variables["MINIAUDIO_VERSION_STRING"] = self.version
+                tc.generate()
+
+            def build(self):
+                if self.options.header_only:
+                    return
+        
+                cmake = CMake(self)
+                cmake.configure(build_script_folder=os.path.join(self.source_folder, os.pardir))
+                cmake.build()
+        
+            def package(self):
+                copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+                copy(
+                    self,
+                    pattern="**",
+                    dst=os.path.join(self.package_folder, "include", "extras"),
+                    src=os.path.join(self.source_folder, "extras"),
+                )
+        
+                if self.options.header_only:
+                    copy(
+                        self,
+                        pattern="miniaudio.h",
+                        dst=os.path.join(self.package_folder, "include"),
+                        src=self.source_folder)
+                    copy(
+                        self,
+                        pattern="miniaudio.*",
+                        dst=os.path.join(self.package_folder, "include", "extras", "miniaudio_split"),
+                        src=os.path.join(self.source_folder, "extras", "miniaudio_split"),
+                    )
+                else:
+                    cmake = CMake(self)
+                    cmake.install()
+        
+            def package_info(self):
+                if self.options.header_only:
+                    self.cpp_info.bindirs = []
+                    self.cpp_info.libdirs = []
+                else:
+                    self.cpp_info.libs = ["miniaudio"]
+                    if self.options.shared:
+                        self.cpp_info.defines.append("MA_DLL")
+
+        """)
+
+    def _get_environ(self, **kwargs):
+        kwargs = super(TestHeaderOnlyExtensions, self)._get_environ(**kwargs)
+        kwargs.update({'CONAN_HOOKS': os.path.join(os.path.dirname(__file__), '..', '..', '..',
+                                                   'hooks', 'conan-center')})
+        return kwargs
+
+    def test_create_header_only(self):
+        tools.save('conanfile.py', content=self.conanfile)
+        output = self.conan(['create', '.', 'miniaudio/0.11.11@', '-o', 'miniaudio:header_only=True'])
+        self.assertIn("[STATIC ARTIFACTS (KB-H074)] OK", output)

--- a/tests/test_hooks/conan-center/test_header_only_extensions.py
+++ b/tests/test_hooks/conan-center/test_header_only_extensions.py
@@ -14,12 +14,9 @@ class TestHeaderOnlyExtensions(ConanClientTestCase):
 
     conanfile = textwrap.dedent("""\
         from conan import ConanFile
-        from conan.tools.files import get, copy
-        from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+        from conan.tools.cmake import cmake_layout
         from conan.tools.layout import basic_layout
         import os
-        
-        required_conan_version = ">=1.53.0"
         
         class MiniaudioConan(ConanFile):
             name = "miniaudio"
@@ -35,16 +32,6 @@ class TestHeaderOnlyExtensions(ConanClientTestCase):
                 "header_only": True,
             }
         
-            def config_options(self):
-                if self.settings.os == "Windows":
-                    del self.options.fPIC
-        
-            def configure(self):
-                if self.options.shared:
-                    self.options.rm_safe("fPIC")
-                self.settings.rm_safe("compiler.libcxx")
-                self.settings.rm_safe("compiler.cppstd")
-        
             def layout(self):
                 if self.options.header_only:
                     basic_layout(self, src_folder="src")
@@ -55,56 +42,10 @@ class TestHeaderOnlyExtensions(ConanClientTestCase):
                 if self.options.header_only:
                     self.info.clear()
         
-            def generate(self):
-                if self.options.header_only:
-                    return
-        
-                tc = CMakeToolchain(self)
-                tc.variables["MINIAUDIO_VERSION_STRING"] = self.version
-                tc.generate()
-
-            def build(self):
-                if self.options.header_only:
-                    return
-        
-                cmake = CMake(self)
-                cmake.configure(build_script_folder=os.path.join(self.source_folder, os.pardir))
-                cmake.build()
-        
-            def package(self):
-                copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
-                copy(
-                    self,
-                    pattern="**",
-                    dst=os.path.join(self.package_folder, "include", "extras"),
-                    src=os.path.join(self.source_folder, "extras"),
-                )
-        
-                if self.options.header_only:
-                    copy(
-                        self,
-                        pattern="miniaudio.h",
-                        dst=os.path.join(self.package_folder, "include"),
-                        src=self.source_folder)
-                    copy(
-                        self,
-                        pattern="miniaudio.*",
-                        dst=os.path.join(self.package_folder, "include", "extras", "miniaudio_split"),
-                        src=os.path.join(self.source_folder, "extras", "miniaudio_split"),
-                    )
-                else:
-                    cmake = CMake(self)
-                    cmake.install()
-        
             def package_info(self):
                 if self.options.header_only:
                     self.cpp_info.bindirs = []
                     self.cpp_info.libdirs = []
-                else:
-                    self.cpp_info.libs = ["miniaudio"]
-                    if self.options.shared:
-                        self.cpp_info.defines.append("MA_DLL")
-
         """)
 
     def _get_environ(self, **kwargs):


### PR DESCRIPTION
- Post package for header-only is already validated. No artifacts is expected
- When is a header-only package, ignores shared=False on post package.

fixes #456 

/cc @toge