### PR TITLE
[conan-center] Do not allow override parameter for self.requires

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -84,6 +84,7 @@ kb_errors = {"KB-H001": "DEPRECATED GLOBAL CPPSTD",
              "KB-H072": "PYLINT EXECUTION",
              "KB-H073": "TEST V1 PACKAGE FOLDER",
              "KB-H074": "STATIC ARTIFACTS",
+             "KB-H075": "REQUIREMENT OVERRIDE PARAMETER",
              }
 
 
@@ -909,6 +910,12 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
                 out.error("The test_package seems be prepared for Conan v2, but test_v1_package is missing.")
             elif not os.path.isfile(test_v1_package_conanfile_path):
                 out.error("There is no 'conanfile.py' in 'test_v1_package' folder")
+
+    @run_test("KB-H075", output)
+    def test(out):
+        match = re.search(r'self.requires\(.*override=True.*\)', conanfile_content)
+        if match:
+            out.error("self.requires('package/version', override=True) is forbidden, do not force override parameter.")
 
 
 @raise_if_error_output

--- a/tests/test_hooks/conan-center/test_forbidden_override.py
+++ b/tests/test_hooks/conan-center/test_forbidden_override.py
@@ -1,0 +1,50 @@
+import os
+import textwrap
+
+from conans import tools
+
+from tests.utils.test_cases.conan_client import ConanClientTestCase
+
+
+class ForbiddenOverrideTests(ConanClientTestCase):
+    conanfile = textwrap.dedent("""\
+        import os
+        from conan import ConanFile
+
+        class AConan(ConanFile):           
+           def requirements(self):
+               {}
+               pass
+ 
+        """)
+
+    def _get_environ(self, **kwargs):
+        kwargs = super(ForbiddenOverrideTests, self)._get_environ(**kwargs)
+        kwargs.update({'CONAN_HOOKS': os.path.join(os.path.dirname(__file__), '..', '..', '..',
+                                                   'hooks', 'conan-center')})
+        return kwargs
+
+    def test_with_override_true(self):
+        tools.save('conanfile.py', content=self.conanfile.replace("{}", "self.requires('package/version', override=True)"))
+        output = self.conan(['export', '.', 'name/version@user/channel'])
+        self.assertIn("ERROR: [REQUIREMENT OVERRIDE PARAMETER (KB-H075)]", output)
+
+    def test_with_override_false(self):
+        tools.save('conanfile.py', content=self.conanfile.replace("{}", "self.requires('package/version', override=False)"))
+        output = self.conan(['export', '.', 'name/version@user/channel'])
+        self.assertIn("[REQUIREMENT OVERRIDE PARAMETER (KB-H075)] OK", output)
+
+    def test_no_requires(self):
+        tools.save('conanfile.py', content=self.conanfile.replace("{}", ""))
+        output = self.conan(['export', '.', 'name/version@user/channel'])
+        self.assertIn("[REQUIREMENT OVERRIDE PARAMETER (KB-H075)] OK", output)
+
+    def test_with_private_false(self):
+        tools.save('conanfile.py', content=self.conanfile.replace("{}", "self.requires('package/version', private=False, override=False)"))
+        output = self.conan(['export', '.', 'name/version@user/channel'])
+        self.assertIn("[REQUIREMENT OVERRIDE PARAMETER (KB-H075)] OK", output)
+
+    def test_with_private_true(self):
+        tools.save('conanfile.py', content=self.conanfile.replace("{}", "self.requires('package/version', override=True, private=False)"))
+        output = self.conan(['export', '.', 'name/version@user/channel'])
+        self.assertIn("ERROR: [REQUIREMENT OVERRIDE PARAMETER (KB-H075)]", output)


### PR DESCRIPTION
The parameter `override` is used to force a specific package version and avoid updating package requirements. As side-effect, it can result in an ABI incompatibility. 