### PR TITLE
Do not enforce KB-H013 on mold

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1087,7 +1087,7 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
     @run_test("KB-H013", output)
     def test(out):
         if conanfile.name in ["cmake", "android-ndk", "zulu-openjdk", "mingw-w64", "mingw-builds",
-                              "openjdk", "mono", "gcc"]:
+                              "openjdk", "mono", "gcc", "mold"]:
             return
 
         base_known_folders = ["lib", "bin", "include", "res", "licenses"]


### PR DESCRIPTION
Mold relies on the `libexec`, which is forbidden by  KB-H013.

Since this folder is pointed out by the mold docs on the "how to use the linker" section, we should include it on the package.

See https://github.com/conan-io/conan-center-index/pull/13666#issuecomment-1344727527
