### PR TITLE
Skip mbits-args from KB-H0007

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1048,6 +1048,8 @@ def pre_build(output, conanfile, **kwargs):
 
     @run_test("KB-H007", output)
     def test(out):
+        if conanfile.name in ["mbits-args"]:
+            return
         has_fpic = conanfile.options.get_safe("fPIC")
         error = False
         if conanfile.settings.get_safe("os") == "Windows" and has_fpic:


### PR DESCRIPTION
Required by https://github.com/conan-io/conan-center-index/pull/14965

The package `mbit-args` does not support shared and removed the `shared` option from the recipe.