### PR TITLE
[conan-center] Accept settings.compiler.rm_safe

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1023,7 +1023,7 @@ def post_source(output, conanfile, conanfile_path, **kwargs):
                 ("del self.settings.compiler.libcxx" not in low and \
                  'self.settings.rm_safe("compiler.libcxx")' not in low and \
                  "self.settings.rm_safe('compiler.libcxx')" not in low and \
-                 'self.settings.compiler.rm_safe("libcxx")' not in low and
+                 'self.settings.compiler.rm_safe("libcxx")' not in low and \
                  "self.settings.compiler.rm_safe('libcxx')"):
                 out.error("Can't detect C++ source files but recipe does not remove "
                           "'self.settings.compiler.libcxx'")
@@ -1036,7 +1036,9 @@ def post_source(output, conanfile, conanfile_path, **kwargs):
             if conanfile.settings.get_safe("compiler") and \
                 ("del self.settings.compiler.cppstd" not in low and \
                  'self.settings.rm_safe("compiler.cppstd")' not in low and \
-                 "self.settings.rm_safe('compiler.cppstd')" not in low):
+                 "self.settings.rm_safe('compiler.cppstd')" not in low and \
+                 'self.settings.compiler.rm_safe("libcxx")' not in low and \
+                 "self.settings.compiler.rm_safe('libcxx')"):
                 out.error("Can't detect C++ source files but recipe does not remove "
                           "'self.settings.compiler.cppstd'")
 

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1022,7 +1022,9 @@ def post_source(output, conanfile, conanfile_path, **kwargs):
             if conanfile.settings.get_safe("compiler") and \
                 ("del self.settings.compiler.libcxx" not in low and \
                  'self.settings.rm_safe("compiler.libcxx")' not in low and \
-                 "self.settings.rm_safe('compiler.libcxx')" not in low):
+                 "self.settings.rm_safe('compiler.libcxx')" not in low and \
+                 'self.settings.compiler.rm_safe("libcxx")' not in low and
+                 "self.settings.compiler.rm_safe('libcxx')"):
                 out.error("Can't detect C++ source files but recipe does not remove "
                           "'self.settings.compiler.libcxx'")
 

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -443,6 +443,13 @@ class ConanCenterTests(ConanClientTestCase):
             self.assertIn("[LIBCXX MANAGEMENT (KB-H011)] OK", output)
             self.assertIn("[CPPSTD MANAGEMENT (KB-H022)] OK", output)
 
+            tools.save('conanfile.py', content=content.format(configure="""
+            self.settings.compiler.rm_safe("libcxx")
+            self.settings.compiler.rm_safe("cppstd")"""))
+            output = self.conan(['create', '.', 'name/version@user/test'])
+            self.assertIn("[LIBCXX MANAGEMENT (KB-H011)] OK", output)
+            self.assertIn("[CPPSTD MANAGEMENT (KB-H022)] OK", output)
+
     def test_missing_attributes(self):
         conanfile = textwrap.dedent("""\
         from conans import ConanFile


### PR DESCRIPTION
The hook `KB-H011` only validates pure_c when `settings.compiler` is present in the recipe, which means, `self.settings.compiler.rm_safe` should work too.

For those cases when `settings` or even `settings.compiler` is removed, does not make any sense removing `libcxx` or `cppstd` too. 


close #471

/cc @prince-chrismc @jcar87 