### PR TITLE
Update kb-h075 to only match active self.requires(..., override=True) statements

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -913,7 +913,7 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
 
     @run_test("KB-H075", output)
     def test(out):
-        match = re.search(r'self.requires\(.*override=True.*\)', conanfile_content)
+        match = re.search(r'(^|\n)\s*self.requires\(.*override=True.*\)', conanfile_content)
         if match:
             out.error("self.requires('package/version', override=True) is forbidden, do not force override parameter.")
 

--- a/tests/test_hooks/conan-center/test_forbidden_override.py
+++ b/tests/test_hooks/conan-center/test_forbidden_override.py
@@ -34,6 +34,11 @@ class ForbiddenOverrideTests(ConanClientTestCase):
         output = self.conan(['export', '.', 'name/version@user/channel'])
         self.assertIn("[REQUIREMENT OVERRIDE PARAMETER (KB-H075)] OK", output)
 
+    def test_with_commented_requires(self):
+        tools.save('conanfile.py', content=self.conanfile.replace("{}", "# self.requires('package/version', override=True)"))
+        output = self.conan(['export', '.', 'name/version@user/channel'])
+        self.assertIn("[REQUIREMENT OVERRIDE PARAMETER (KB-H075)] OK", output)
+
     def test_no_requires(self):
         tools.save('conanfile.py', content=self.conanfile.replace("{}", ""))
         output = self.conan(['export', '.', 'name/version@user/channel'])


### PR DESCRIPTION
Fix hook for KB-H075 to ensure that it only matches self.requires statements that are active code. This ensures that it doesn't match similar strings that appear in comments, which may be common when providing advice to consumers.

This prevents the following from being matched:

```python
def requirements(self):
    # self.requires("pkg/version@user/channel", override=True)
```
by ensuring that only lines with only preceeding whitespace are matched. In this case, the following would be matched:

```python
def requirements(self):
    self.requires("pkg/version@user/channel", override=True) # anything here won't affect match
```

Closes #473 