### PR TITLE
Fix Hook url for Conan Center

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -165,7 +165,7 @@ def raise_if_error_output(func):
 
 
 def kb_url(kb_id):
-    return "https://github.com/conan-io/conan-center-index/blob/master/docs/error_knowledge_base.md#{}".format(kb_id)
+    return "https://github.com/conan-io/conan-center-index/blob/master/docs/error_knowledge_base.md#{}-{}".format(kb_id, kb_errors[kb_id].replace(' ', '-'))
 
 
 def run_test(kb_id, output):


### PR DESCRIPTION
The hooks were generating URLs with only the hook id set as the anchor which to scroll in the document, but the ID of the element also contains the hook title https://github.com/conan-io/conan-center-index/blob/master/docs/error_knowledge_base.md#kb-h076-either-static-or-shared-of-each-lib