### PR TITLE
Skip mawk for Conan center hook

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1003,6 +1003,9 @@ def post_source(output, conanfile, conanfile_path, **kwargs):
 
     @run_test("KB-H011", output)
     def test(out):
+        if conanfile.name in ['mawk']:
+            return
+
         if _is_pure_c():
             conanfile_content = tools.load(conanfile_path)
             low = conanfile_content.lower()
@@ -1018,6 +1021,9 @@ def post_source(output, conanfile, conanfile_path, **kwargs):
 
     @run_test("KB-H022", output)
     def test(out):
+        if conanfile.name in ['mawk']:
+            return
+
         if _is_pure_c():
             conanfile_content = tools.load(conanfile_path)
             low = conanfile_content.lower()


### PR DESCRIPTION
The mawk is an application and its settings are managed by the package_id method already. No compiler, neither build_type considered. 

Required by https://github.com/conan-io/conan-center-index/pull/17606 