### PR TITLE
Skip tz from layout hook

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1128,6 +1128,7 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
             "create-dmg",
             "googleapis",
             "grpc-proto",
+            "tz",
         ]:
             return
         if not _files_match_settings(conanfile, conanfile.package_folder, out):


### PR DESCRIPTION
Required for https://github.com/conan-io/conan-center-index/pull/16284

Instead of moving timezone files, let's keep the original layout and adapt cpp_info.