### PR TITLE
[gawk] Add exception for KB-H013

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1087,7 +1087,7 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
     @run_test("KB-H013", output)
     def test(out):
         if conanfile.name in ["cmake", "android-ndk", "zulu-openjdk", "mingw-w64", "mingw-builds",
-                              "openjdk", "mono", "gcc", "mold", "tz"]:
+                              "openjdk", "mono", "gcc", "mold", "tz", "gawk"]:
             return
 
         base_known_folders = ["lib", "bin", "include", "res", "licenses"]


### PR DESCRIPTION
This resolves an issue where the recipe fails hooks in conan-io/conan-center-index#16798 because it uses the gnu standard package layout.

See logs: https://c3i.jfrog.io/c3i/misc/logs/pr/16798/9-linux-gcc/gawk/5.2.1//effd5e9c4f3a67f5e13f85feec36a2debc2f566c-build.txt