### PR TITLE
add maven to KB-H013 exception lists

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1087,7 +1087,7 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
     @run_test("KB-H013", output)
     def test(out):
         if conanfile.name in ["cmake", "android-ndk", "zulu-openjdk", "mingw-w64", "mingw-builds",
-                              "openjdk", "mono", "gcc", "mold", "tz", "gawk"]:
+                              "openjdk", "mono", "gcc", "mold", "tz", "gawk", "maven"]:
             return
 
         base_known_folders = ["lib", "bin", "include", "res", "licenses"]


### PR DESCRIPTION
Same reason of https://github.com/conan-io/hooks/pull/498.

I'm creating maven recipe on conan-center-index.
https://github.com/conan-io/conan-center-index/pull/17868

maven requires `boot` and `conf` folders which are not included `base_known_folders`.
So I want to add maven to exception lists.