### PR TITLE
[conan-center] KB-H013 should be skipped for binutils package

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1087,7 +1087,7 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
     @run_test("KB-H013", output)
     def test(out):
         if conanfile.name in ["cmake", "android-ndk", "zulu-openjdk", "mingw-w64", "mingw-builds",
-                              "openjdk", "mono", "gcc", "mold", "tz", "gawk", "maven"]:
+                              "openjdk", "mono", "gcc", "mold", "tz", "gawk", "maven", "binutils"]:
             return
 
         base_known_folders = ["lib", "bin", "include", "res", "licenses"]


### PR DESCRIPTION
The PR https://github.com/conan-io/conan-center-index/pull/16920 wants to install the etc folder in package folder. It would be needed to change the layout to avoid KB-H013 error, but will be better skipping it instead to forcing the package breaking its natural layout.