### PR TITLE
Add ua-nodeset to allowlist for KB-H014

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1128,7 +1128,8 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
             "create-dmg",
             "googleapis",
             "grpc-proto",
-            "scons"
+            "scons",
+            "ua-nodeset",
         ]:
             return
         if not _files_match_settings(conanfile, conanfile.package_folder, out):


### PR DESCRIPTION
Needed to unblock https://github.com/conan-io/conan-center-index/pull/18108

The package consists of only `*.res` files, needed by [`open62541`](https://github.com/conan-io/conan-center-index/blob/master/recipes/open62541/all/conanfile.py#L13).

I'm wondering if it would have been more sensible to simply merge `ua-nodeset` into `open62541`. As far as I understand it it's always needed when using the library anyway:
* https://github.com/conan-io/conan-center-index/pull/7314#issuecomment-940692444
* https://github.com/conan-io/conan-center-index/blob/2a2ba02db3fbcc473606f57912baa393452c4de1/recipes/open62541/all/test_package/conanfile.py#L15-L23