### PR TITLE
removed public domain restriction

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -951,11 +951,6 @@ def post_export(output, conanfile, conanfile_path, reference, **kwargs):
         if default_options and isinstance(default_options, dict) and default_options.get("shared") is True:
             out.error("The option 'shared' must be 'False' by default. Update 'default_options'.")
 
-    @run_test("KB-H056", output)
-    def test(out):
-        if str(conanfile.license).lower() in ["public domain", "public-domain", "public_domain"]:
-            out.error("Public Domain is not a SPDX license. Use 'Unlicense' instead.")
-
 
 @raise_if_error_output
 def pre_source(output, conanfile, conanfile_path, **kwargs):

--- a/tests/test_hooks/conan-center/test_conan-center.py
+++ b/tests/test_hooks/conan-center/test_conan-center.py
@@ -991,18 +991,6 @@ class ConanCenterTests(ConanClientTestCase):
         output = self.conan(['export', '.', 'name/version@user/test'])
         self.assertIn("[SINGLE REQUIRES (KB-H055)] OK", output)
 
-    def test_public_domain_license(self):
-        conanfile = textwrap.dedent("""\
-        from conans import ConanFile
-        class AConan(ConanFile):
-            license = "Public Domain"
-        """)
-
-        tools.save('conanfile.py', content=conanfile)
-        output = self.conan(['export', '.', 'name/version@user/test'])
-        self.assertIn("ERROR: [LICENSE PUBLIC DOMAIN (KB-H056)] " \
-                      "Public Domain is not a SPDX license. Use 'Unlicense' instead.", output)
-
     def test_os_rename_warning(self):
         conanfile = textwrap.dedent("""\
         from conans import ConanFile, tools


### PR DESCRIPTION
If some library defines it is "public domain", but it doesn't give any further detail, or provide a license file, Conan cannot say it is an "unlicense" license, and definitely not download a copy from unlicense.org. It is not the same, and the original repository terms should be respected. The README or any other file that cites it is public-domain should be the one being packaged in the "license" folder