### PR TITLE
Avoid installing pyyaml 6.0.0

### DIFF
--- a/tests/requirements_test.txt
+++ b/tests/requirements_test.txt
@@ -6,4 +6,4 @@ pylint==2.13.9  # FIXME: Remove version pin for Conan >= 1.50.0
 astroid
 spdx_lookup
 yamllint
-pyyaml<=6.0
+pyyaml<6.0

--- a/tests/requirements_test.txt
+++ b/tests/requirements_test.txt
@@ -6,3 +6,4 @@ pylint==2.13.9  # FIXME: Remove version pin for Conan >= 1.50.0
 astroid
 spdx_lookup
 yamllint
+pyyaml<=6.0

--- a/tests/requirements_test.txt
+++ b/tests/requirements_test.txt
@@ -6,4 +6,4 @@ pylint==2.13.9  # FIXME: Remove version pin for Conan >= 1.50.0
 astroid
 spdx_lookup
 yamllint
-pyyaml!=6.0.0,!=5.4.0,!=5.4.1
+pyyaml==5.3.1

--- a/tests/requirements_test.txt
+++ b/tests/requirements_test.txt
@@ -6,4 +6,4 @@ pylint==2.13.9  # FIXME: Remove version pin for Conan >= 1.50.0
 astroid
 spdx_lookup
 yamllint
-pyyaml<6.0
+pyyaml!=6.0.0,!=5.4.0,!=5.4.1


### PR DESCRIPTION
Hooks tests are broken because we can't install PyYAML 6.0.0

```
Collecting PyYAML<=6.0,>=3.11 (from conan==1.60.0)

  Using cached https://files.pythonhosted.org/packages/36/2b/61d51a2c4f25ef062ae3f74576b01638bebad5e045f747ff12643df63844/PyYAML-6.0.tar.gz

  Installing build dependencies: started

  Installing build dependencies: finished with status 'done'

    Complete output from command python setup.py egg_info:

    running egg_info

    creating pip-egg-info/PyYAML.egg-info

    writing pip-egg-info/PyYAML.egg-info/PKG-INFO

    writing dependency_links to pip-egg-info/PyYAML.egg-info/dependency_links.txt

    writing top-level names to pip-egg-info/PyYAML.egg-info/top_level.txt

    writing manifest file 'pip-egg-info/PyYAML.egg-info/SOURCES.txt'

    Traceback (most recent call last):

      File "<string>", line 1, in <module>

      File "/private/var/folders/59/4z5w84h155g6vgxb0xf8g96w0000gp/T/pip-install-v1b049v6/PyYAML/setup.py", line 312, in <module>

        python_requires='>=3.6',

      File "/private/var/folders/59/4z5w84h155g6vgxb0xf8g96w0000gp/T/pip-build-env-5vlmcvxc/lib/python3.6/site-packages/setuptools/__init__.py", line 153, in setup

        return distutils.core.setup(**attrs)

      File "/Users/jenkins/.pyenv/versions/3.6.15/lib/python3.6/distutils/core.py", line 148, in setup

        dist.run_commands()

      File "/Users/jenkins/.pyenv/versions/3.6.15/lib/python3.6/distutils/dist.py", line 955, in run_commands

        self.run_command(cmd)

      File "/Users/jenkins/.pyenv/versions/3.6.15/lib/python3.6/distutils/dist.py", line 974, in run_command

        cmd_obj.run()

      File "/private/var/folders/59/4z5w84h155g6vgxb0xf8g96w0000gp/T/pip-build-env-5vlmcvxc/lib/python3.6/site-packages/setuptools/command/egg_info.py", line 299, in run

        self.find_sources()

      File "/private/var/folders/59/4z5w84h155g6vgxb0xf8g96w0000gp/T/pip-build-env-5vlmcvxc/lib/python3.6/site-packages/setuptools/command/egg_info.py", line 306, in find_sources

        mm.run()

      File "/private/var/folders/59/4z5w84h155g6vgxb0xf8g96w0000gp/T/pip-build-env-5vlmcvxc/lib/python3.6/site-packages/setuptools/command/egg_info.py", line 541, in run

        self.add_defaults()

      File "/private/var/folders/59/4z5w84h155g6vgxb0xf8g96w0000gp/T/pip-build-env-5vlmcvxc/lib/python3.6/site-packages/setuptools/command/egg_info.py", line 578, in add_defaults

        sdist.add_defaults(self)

      File "/private/var/folders/59/4z5w84h155g6vgxb0xf8g96w0000gp/T/pip-build-env-5vlmcvxc/lib/python3.6/site-packages/setuptools/command/py36compat.py", line 34, in add_defaults

        self._add_defaults_ext()

      File "/private/var/folders/59/4z5w84h155g6vgxb0xf8g96w0000gp/T/pip-build-env-5vlmcvxc/lib/python3.6/site-packages/setuptools/command/py36compat.py", line 118, in _add_defaults_ext

        self.filelist.extend(build_ext.get_source_files())

      File "/private/var/folders/59/4z5w84h155g6vgxb0xf8g96w0000gp/T/pip-install-v1b049v6/PyYAML/setup.py", line 204, in get_source_files

        self.cython_sources(ext.sources, ext)

      File "/Users/jenkins/.pyenv/versions/3.6.15/lib/python3.6/distutils/cmd.py", line 103, in __getattr__

        raise AttributeError(attr)

    AttributeError: cython_sources
```

There is a related open issue https://github.com/yaml/pyyaml/issues/601, https://github.com/yaml/pyyaml/issues/724

Meanwhile, let's run an older version. 