### PR TITLE
Skip KB-H014 for directx-headers

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1125,7 +1125,8 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
             "create-dmg",
             "googleapis",
             "grpc-proto",
-            "scons"
+            "scons",
+            "directx-headers"
         ]:
             return
         if not _files_match_settings(conanfile, conanfile.package_folder, out):


### PR DESCRIPTION
Related to #516 and https://github.com/conan-io/conan-center-index/pull/20623

Meson indeed generates .a for static libraries on Windows. 

/cc @jwillikers