### PR TITLE
Add MATCHING CONFIGURATION exception for makefile-project-workspace-creator

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1122,6 +1122,7 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
             "extra-cmake-modules",
             "gnu-config",
             "gtk-doc-stub",
+            "makefile-project-workspace-creator",
             "ms-gsl",
             "poppler-data",
             "wayland-protocols",


### PR DESCRIPTION
For https://github.com/conan-io/conan-center-index/pull/18938

I suppose `.pl` and maybe `.py` could also be added as acceptable extensions instead.