### PR TITLE
[conan-center-index] KB-H009 Skip Boost recipe

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -246,6 +246,10 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
 
     @run_test("KB-H009", output)
     def test(out):
+        allowlist = ("boost",)
+        if conanfile.name in allowlist:
+            out.info("'{}' is part of the allowlist, skipping.".format(conanfile.name))
+            return
         max_folder_size = int(os.getenv("CONAN_MAX_RECIPE_FOLDER_SIZE_KB", 256))
         dir_path = os.path.dirname(conanfile_path)
         total_size = 0


### PR DESCRIPTION
The hook KB-H009 allows only recipe folders with 256KB size, consider only Conan recipe, test package and patches, it should more than enough.

However, Boost exceeds it due its high number of files in the repository. It needs an exception to work.

Related to https://github.com/conan-io/conan-center-index/pull/21747#issuecomment-1869257003