### PR TITLE
[conan-center] Skip KB-H016 for gettext

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1180,7 +1180,7 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
     @run_test("KB-H016", output)
     def test(out):
         if conanfile.name in ["cmake", "msys2", "strawberryperl", "pybind11", "ignition-cmake",
-                              "extra-cmake-modules", "emsdk"]:
+                              "extra-cmake-modules", "emsdk", "gettext"]:
             return
         bad_files = _get_files_following_patterns(conanfile.package_folder, ["Find*.cmake",
                                                                              "*Config.cmake",


### PR DESCRIPTION
Related to the PR https://github.com/conan-io/conan-center-index/pull/21351

The Gettext should provides 2 cmake files, one for libintl (FindIntl.cmake) and another to gettext binaries (FindGettext.cmake). Currently, is not possible to generate more than 1 .cmake using CMakeDeps, so we need to copy it directly from the exported folder and use CMake variables defined by Conan.