### PR TITLE
conan-center.py: add an exception for `tz`

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1138,7 +1138,8 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
             "googleapis",
             "grpc-proto",
             "scons",
-            "directx-headers"
+            "directx-headers",
+            "tz",
         ]:
             return
         if not _files_match_settings(conanfile, conanfile.package_folder, out):


### PR DESCRIPTION
To fix the invalid linter error in https://github.com/conan-io/conan-center-index/pull/21671
```
[HOOK - conan-center.py] post_package(): ERROR: [MATCHING CONFIGURATION (KB-H014)] Package for Header Only does not contain artifacts with these extensions: ['h', 'h++', 'hh', 'hxx', 'hpp', 'cuh'] (https://github.com/conan-io/conan-center-index/blob/master/docs/error_knowledge_base.md#KB-H014-MATCHING-CONFIGURATION) 
[HOOK - conan-center.py] post_package(): ERROR: [MATCHING CONFIGURATION (KB-H014)] Packaged artifacts does not match the settings used: os=Linux, compiler=gcc (https://github.com/conan-io/conan-center-index/blob/master/docs/error_knowledge_base.md#KB-H014-MATCHING-CONFIGURATION) 
```