### PR TITLE
add battery-embed to KB-H014 allowlist

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1140,6 +1140,7 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
             "scons",
             "directx-headers",
             "tz",
+            "battery-embed",
         ]:
             return
         if not _files_match_settings(conanfile, conanfile.package_folder, out):


### PR DESCRIPTION
I want to add "battery-embed" recipe which provides only cmake module.
https://github.com/conan-io/conan-center-index/pull/22698