### PR TITLE
Remove `conandata.yml` field limits

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -373,7 +373,7 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
     def test(out):
         conandata_path = os.path.join(export_folder_path, "conandata.yml")
         version = conanfile.version
-        allowed_first_level = ["sources", "patches"]
+        allowed_first_level = ["sources", "patches", "extra"]
         allowed_sources = ["md5", "sha1", "sha256", "url"]
         allowed_patches = ["patch_file", "base_path", "url", "sha256", "sha1", "md5", "patch_type", "patch_source", "patch_description"]
         if conanfile.name in ["openssh", "gmp"]:

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -373,7 +373,6 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
     def test(out):
         conandata_path = os.path.join(export_folder_path, "conandata.yml")
         version = conanfile.version
-        allowed_first_level = ["sources", "patches", "extra"]
         allowed_sources = ["md5", "sha1", "sha256", "url"]
         allowed_patches = ["patch_file", "base_path", "url", "sha256", "sha1", "md5", "patch_type", "patch_source", "patch_description"]
         if conanfile.name in ["openssh", "gmp"]:
@@ -399,10 +398,6 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
         conandata_yml = load_yml(conandata_path)
         if not conandata_yml:
             return
-        entries = _not_allowed_entries(list(conandata_yml.keys()), allowed_first_level)
-        if entries:
-            out.error("First level entries %s not allowed. Use only first level entries %s in "
-                      "conandata.yml" % (entries, allowed_first_level))
 
         google_source_regex = re.compile(r"https://\w+.googlesource.com/")
 

--- a/tests/test_hooks/conan-center/test_conandata.py
+++ b/tests/test_hooks/conan-center/test_conandata.py
@@ -369,7 +369,7 @@ class ConanData(ConanClientTestCase):
         output = self.conan(['export', '.', 'name/1.70.0@jgsogo/test'])
         self.assertIn("ERROR: [CONANDATA.YML FORMAT (KB-H030)]", output)
         self.assertIn("First level entries ['random_field'] not allowed. Use only first "
-                      "level entries ['sources', 'patches'] in conandata.yml", output)
+                      "level entries ['sources', 'patches', 'extra'] in conandata.yml", output)
 
     def test_unknown_subentry_sources(self):
         tools.save('conanfile.py', content=self.conanfile)

--- a/tests/test_hooks/conan-center/test_conandata.py
+++ b/tests/test_hooks/conan-center/test_conandata.py
@@ -360,17 +360,6 @@ class ConanData(ConanClientTestCase):
         output = self.conan(['export', '.', 'name/1.70.0@jgsogo/test'])
         self.assertIn("ERROR: [CONANDATA.YML FORMAT (KB-H030)] Versions in conandata.yml should be strings", output)
 
-    def test_unknown_field(self):
-        tools.save('conanfile.py', content=self.conanfile)
-        conandata = textwrap.dedent("""
-            random_field: "random"
-            """)
-        tools.save('conandata.yml', content=conandata)
-        output = self.conan(['export', '.', 'name/1.70.0@jgsogo/test'])
-        self.assertIn("ERROR: [CONANDATA.YML FORMAT (KB-H030)]", output)
-        self.assertIn("First level entries ['random_field'] not allowed. Use only first "
-                      "level entries ['sources', 'patches', 'extra'] in conandata.yml", output)
-
     def test_unknown_subentry_sources(self):
         tools.save('conanfile.py', content=self.conanfile)
         conandata = textwrap.dedent("""


### PR DESCRIPTION
This will allow to have an extra fields in the `conandata.yml` file, which is meant to contain things that the recipes use on a per version basis.
ie, `wasmtime-cpp` (Among many others) contains a version mapping inside the recipe, so every time a new version is added, the revisions of every other version also get modified (https://github.com/conan-io/conan-center-index/pull/23172/files#diff-1a9d4053acc279660d5b2b73ca7f473b969b33b25621bdad9465c9da9f84fd65R47)

This allows the `trim_conandata` hook to keep the old revisions for older versions :)

Note that we'll be conservative when allowing these fields in PR reviews, so a good reason might need to be provided in order for us to accept these if its usage falls outside the example shown below

The idea is to move those kinds of mappings
from
```py
version_map = {
            "0.35.0": "0.35.1",
            "0.39.0": "0.39.1",
            "1.0.0": "1.0.1",
            "6.0.0": "6.0.1",
            "9.0.0": "12.0.2",
            "18.0.0": "18.0.3",
        }
selected = version_map[self.version]
```
to
conandata.yml
```yml
"extra":
   "0.35.0":
      "requirement": "0.35.1"
   "0.39.0":
      "requirement": "0.39.1"
   "1.0.0":
      "requirement": "1.0.1"
   "6.0.0":
      "requirement": "6.0.1"
   "9.0.0":
      "requirement": "12.0.2"
   "18.0.0":
      "requirement": "18.0.3"
```
conanfile.py
```py
selected = self.conan_data.get("extra")[self.version]["requirement"]
```

or similar :)