### PR TITLE
Add a linter exception for `gfortran`

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1118,7 +1118,8 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
     @run_test("KB-H013", output)
     def test(out):
         if conanfile.name in ["cmake", "android-ndk", "zulu-openjdk", "mingw-w64", "mingw-builds",
-                              "openjdk", "mono", "gcc", "mold", "tz", "gawk", "maven", "binutils"]:
+                              "openjdk", "mono", "gcc", "mold", "tz", "gawk", "maven", "binutils",
+                              "gfortran"]:
             return
 
         base_known_folders = ["lib", "bin", "include", "res", "licenses"]


### PR DESCRIPTION
Add an exception for `gfortran` to the `DEFAULT PACKAGE LAYOUT` check.

Like other GCC packages, https://github.com/conan-io/conan-center-index/pull/23334 otherwise fails due to `libexec` being present in the package folder.

GCC uses `libexec` for internal tools and plugins that should not be exposed on PATH.

Perhaps `libexec` itself could be added to the `base_known_folders = ["lib", "bin", "include", "res", "licenses"]` list? Packages that rely on `libexec` usually do it for a good reason and reconfiguring the directory layouts can be difficult.