### PR TITLE
Relax conandata.yml hook for patches and make strict for url

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -378,7 +378,7 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
     def test(out):
         conandata_path = os.path.join(export_folder_path, "conandata.yml")
         version = conanfile.version
-        allowed_sources = ["sha256", "url"]
+        allowed_sources = ["sha256", "md5", "sha1", "url"]
 
         checksums = [ "sha256"]
         found_checksums = []

--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -378,18 +378,9 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
     def test(out):
         conandata_path = os.path.join(export_folder_path, "conandata.yml")
         version = conanfile.version
-        allowed_sources = ["md5", "sha1", "sha256", "url"]
-        allowed_patches = ["patch_file", "base_path", "url", "sha256", "sha1", "md5", "patch_type", "patch_source", "patch_description"]
+        allowed_sources = ["sha256", "url"]
 
-        extra_allowed_patches = {
-            "openssh": ["patch_os", "patch_os_version"],
-            "gmp": ["patch_os"]
-        }
-
-        allowed_patches.extend(extra_allowed_patches.get(conanfile.name, []))
-
-        weak_checksums = ["md5", "sha1"]
-        checksums = ["md5", "sha1", "sha256"]
+        checksums = [ "sha256"]
         found_checksums = []
         has_sources = False
         is_google_source = False
@@ -469,10 +460,6 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
             if version not in conandata_yml[entry]:
                 continue
             for element in conandata_yml[entry][version]:
-                if entry == "patches":
-                    if not validate_recursive(element, conandata_yml[entry][version], "patches",
-                                              allowed_patches):
-                        return
                 if entry == "sources":
                     if not validate_recursive(element, conandata_yml[entry][version], "sources",
                                               allowed_sources):
@@ -483,9 +470,6 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
                     validate_checksum_recursive(element, conandata_yml[entry][version])
             if not found_checksums and has_sources and not is_google_source:
                 out.error("The checksum key 'sha256' must be declared and can not be empty.")
-            elif found_checksums and 'sha256' not in found_checksums:
-                out.warn(f"Consider 'sha256' instead of {weak_checksums}. It's considerably more secure than others.")
-
 
     @run_test("KB-H034", output)
     def test(out):

--- a/tests/test_hooks/conan-center/test_conandata.py
+++ b/tests/test_hooks/conan-center/test_conandata.py
@@ -385,10 +385,7 @@ class ConanData(ConanClientTestCase):
             """)
         tools.save('conandata.yml', content=conandata)
         output = self.conan(['export', '.', 'name/1.70.0@jgsogo/test'])
-        self.assertIn("ERROR: [CONANDATA.YML FORMAT (KB-H030)]", output)
-        self.assertNotIn("First level entries", output)
-        self.assertIn("Additional entries ['patches'] not allowed in 'patches':'1.70.0' "
-                      "of conandata.yml", output)
+        self.assertNotIn("ERROR: [CONANDATA.YML FORMAT (KB-H030)]", output)
 
     def test_unknown_subentry_in_list(self):
         tools.save('conanfile.py', content=self.conanfile)
@@ -404,11 +401,7 @@ class ConanData(ConanClientTestCase):
             """)
         tools.save('conandata.yml', content=conandata)
         output = self.conan(['export', '.', 'name/1.70.0@jgsogo/test'])
-        self.assertIn("ERROR: [CONANDATA.YML FORMAT (KB-H030)]", output)
-
-        self.assertNotIn("First level entries", output)
-        self.assertIn("Additional entries ['other_field'] not allowed in 'patches':'1.70.0' "
-                      "of conandata.yml", output)
+        self.assertNotIn("ERROR: [CONANDATA.YML FORMAT (KB-H030)]", output)
 
     def test_empty_checksum(self):
         tools.save('conanfile.py', content=self.conanfile)
@@ -423,34 +416,15 @@ class ConanData(ConanClientTestCase):
         self.assertIn("ERROR: [CONANDATA.YML FORMAT (KB-H030)]", output)
         self.assertIn("The entry 'sha256' cannot be empty in conandata.yml.", output)
 
-    def test_prefer_sha256(self):
-        tools.save('conanfile.py', content=self.conanfile)
-        for checksum in ['md5', 'sha1']:
-            conandata = textwrap.dedent(f"""
-                sources:
-                  "1.70.0":
+    def test_prefer_sha256_and_others(self):
+        conandata = textwrap.dedent("""
+            sources:
+                "1.70.0":
                     url: "url1.69.0"
-                    {checksum}: "cf23df2207d99a74fbe169e3eba035e633b65d94"
-                """)
-            tools.save('conandata.yml', content=conandata)
-            output = self.conan(['export', '.', 'name/1.70.0@jgsogo/test'])
-            self.assertIn("WARN: [CONANDATA.YML FORMAT (KB-H030)]", output)
-            self.assertIn("Consider 'sha256' instead of ['md5', 'sha1']. It's considerably more secure than others.", output)
-
-            conandata = textwrap.dedent(f"""
-                            sources:
-                              "1.69.0":
-                                url: "url1.69.0"
-                                {checksum}: "cf23df2207d99a74fbe169e3eba035e633b65d94"
-                              "1.70.0":
-                                url: "url1.70.0"
-                                {checksum}: "cf23df2207d99a74fbe169e3eba035e633b65d94"
-                            """)
-            tools.save('conandata.yml', content=conandata)
-            output = self.conan(['export', '.', 'name/1.70.0@jgsogo/test'])
-            self.assertIn("WARN: [CONANDATA.YML FORMAT (KB-H030)]", output)
-            self.assertIn("Consider 'sha256' instead of ['md5', 'sha1']. It's considerably more secure than others.",
-                          output)
+                    sha1: "sha1.69.0"
+                    sha256: "sha256.69.0"
+            """)
+        self._check_conandata(conandata)
 
     def test_empty_checksum(self):
         tools.save('conanfile.py', content=self.conanfile)


### PR DESCRIPTION
* Allow customizing the fields for patches - additional can be okay if justified. If the minimal ones are not there, apply conandata patches will fail (and that should be enough of a check)
* For URLs, disallow checksums that are not `sha256` moving forward


