### PR TITLE
[conan-center] Skip KB-H074 for yomm2 recipe

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1168,7 +1168,7 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
 
     @run_test("KB-H074", output)
     def test(out):
-        if conanfile.name in ["mbits-args"]:
+        if conanfile.name in ["mbits-args", "yomm2"]:
             return
         if not _static_files_well_managed(conanfile, conanfile.package_folder):
             out.error("Package with 'shared=False' option did not contain any static artifact")


### PR DESCRIPTION
Related to https://github.com/conan-io/conan-center-index/pull/23920

The Yomm2 project produces OR a shared library OR header-only. No static library is provided.

/cc @franramirez688 