### PR TITLE
Skip KB-H013 for DBUS

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1110,7 +1110,7 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
     def test(out):
         if conanfile.name in ["cmake", "android-ndk", "zulu-openjdk", "mingw-w64", "mingw-builds",
                               "openjdk", "mono", "gcc", "mold", "tz", "gawk", "maven", "binutils",
-                              "gfortran", "qt"]:
+                              "gfortran", "qt", "dbus"]:
             return
 
         base_known_folders = ["lib", "bin", "include", "res", "licenses"]


### PR DESCRIPTION
Related to https://github.com/conan-io/conan-center-index/pull/24457

DBUS uses `var` folder to store configuration to dbus-deamon and it's the expected by default.