### PR TITLE
add metal cpp to skip KB-H061

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -734,7 +734,7 @@ def pre_export(output, conanfile, conanfile_path, reference, **kwargs):
 
     @run_test("KB-H061", output)
     def test(out):
-        allowlist = ("qt",)
+        allowlist = ("qt", "metal-cpp")
         if conanfile.name in allowlist:
             out.info("'{}' is part of the allowlist, skipping.".format(conanfile.name))
             return


### PR DESCRIPTION
let this recipe call the xcrun utility in the validate method, as a last resort
