### PR TITLE
Add mtfmt to list of allowed non standard package layouts

### DIFF
--- a/hooks/conan-center.py
+++ b/hooks/conan-center.py
@@ -1085,7 +1085,7 @@ def post_package(output, conanfile, conanfile_path, **kwargs):
     def test(out):
         if conanfile.name in ["cmake", "android-ndk", "zulu-openjdk", "mingw-w64", "mingw-builds",
                               "openjdk", "mono", "gcc", "mold", "tz", "gawk", "maven", "binutils",
-                              "gfortran", "qt", "dbus"]:
+                              "gfortran", "qt", "dbus", "mtfmt"]:
             return
 
         base_known_folders = ["lib", "bin", "include", "res", "licenses"]


### PR DESCRIPTION
It packages everything under the mtfmt/ folder

For https://github.com/conan-io/conan-center-index/pull/24634